### PR TITLE
Status in the CSS class, cleaned up Javascript

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -25,7 +25,7 @@
   team:
   licenses:
   links:
-  status: Development
+  status: discovery
 - project: FBOpen
   name: fbopen 
   github: https://github.com/18F/fbopen
@@ -39,7 +39,7 @@
   team:
   licenses:
   links:
-  status:
+  status: alpha
 - project: FOIA Hub
   name: foia-hub
   github: https://github.com/18F/foia-hub
@@ -53,7 +53,7 @@
   team:
   licenses:
   links:
-  status:
+  status: beta
 - project: Midas
   name: midas 
   github: https://github.com/18F/midas
@@ -67,7 +67,7 @@
   team:
   licenses:
   links:
-  status:
+  status: alpha
 - project: openFEC
   name: openFEC 
   github: https://github.com/18F/openFEC
@@ -81,7 +81,7 @@
   team:
   licenses:
   links:
-  status:
+  status: discovery
 - project: "/Developer program"
   name: API-All-the-X
   github: https://github.com/18F/API-All-the-X

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -25,7 +25,7 @@
   team:
   licenses:
   links:
-  status:
+  status: Development
 - project: FBOpen
   name: fbopen 
   github: https://github.com/18F/fbopen

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -19,11 +19,11 @@ layout: bare
       <div>
         <div>
           <h1>status</h1>
-          <p class="status">{{ project.status }}</p>
+          <p class="status {{ project.status }}">{{ project.status }}</p>
         </div>
         <div>
           <h1>issues</h1>
-          <p>138</p>
+          <p class="issues"></p>
         </div>
         <div class="dash-info-long">
           <h1>impact</h1>
@@ -47,11 +47,11 @@ layout: bare
       <div>
         <div>
           <h1>stars</h1>
-          <p>342</p>
+          <p class="stars"></p>
         </div>
         <div>
           <h1>forks</h1>
-          <p>55</p>
+          <p class="forks"></p>
         </div>
         <div>
           <h1>contact</h1>
@@ -62,3 +62,5 @@ layout: bare
   
   {% endif %}
 {% endfor %}
+<script src="/assets/js/underscore.js"></script>
+<script src="/assets/js/main.js"></script>

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -743,7 +743,6 @@ $tiniest: new-breakpoint(max-width 390px);
 	}
 }
 .status {
-	background-color: lighten($blue, 10%);
 	border: $medium-blue;
 	padding: 5px 10px 5px 10px;
 	color: white;
@@ -751,6 +750,23 @@ $tiniest: new-breakpoint(max-width 390px);
 	font-size: .8em;
 	display: inline-block;
 }
+
+.discovery {
+	background-color: lighten($red, 10%);
+}
+
+.alpha {
+	background-color: lighten($medium-blue, 10%);	
+}
+
+.beta {
+	background-color: lighten($green, 10%);
+}
+
+.live {
+	background-color: lighten($blue, 10%);
+}
+
 .dash-info-area {
 	@include span-columns(12);
 	> div {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,11 +9,11 @@ modules[0] = function(repo_name) {
       var stars = data['Stargazers'];
       var forks = data['Forks'];
       var name = repo_name.replace(/[\. ,:-]+/g, "-");
-      $("#"+name+" .issues").append(""+issues);
-      $("#"+name+" .stars").append(""+stars);
-      $("#"+name+" .forks").append(""+forks);      
+      $(".issues").append(""+issues);
+      $(".stars").append(""+stars);
+      $(".forks").append(""+forks);      
     }).error(function () {
-      $("#"+name+" .issues").append("Not available.");
+      $(".issues").append("Not available.");
 });
 }
 
@@ -23,12 +23,12 @@ modules[1] = function(repo_name) {
         status = data.content;
         var repo_name = repo_name.replace(/[\. ,:-]+/g, "-");
         if (typeof data.content != 'undefined' ) {
-      	  $("#"+repo_name+" .status").text(atob(data.content));
+      	  $(".status").text(atob(data.content));
         } else {
-      	  $("#"+repo_name+" .status").text("No status available for this repo yet. Check back soon.");
+      	  $(".status").text("No status available for this repo yet. Check back soon.");
         }
       }).error(function () {
-       $("#"+repo_name+" .status").text("No status available for this repo yet. Check back soon.");
+       $(".status").text("No status available for this repo yet. Check back soon.");
     }
   );
 }
@@ -41,16 +41,13 @@ var render_modules = function(projects) {
   _.map(projects,function(project) {
       modules[0](project.name);
   });
-  _.map(projects,function(project) {
-      modules[1](project.name);
-  });
 }
 
 var render_dashboard = function() {
-  var elements = $(".dashboard-projects-content");
+  var elements = $(document);
   var projects = []
   var content = _.map(elements, function(e) {
-    var ghUrl = $(e).find(".github-url").attr("href");
+    var ghUrl = $(".github-url").attr("href");
     var slugIndex = ghUrl.lastIndexOf("/");
     var name = ghUrl.substr(slugIndex+1);
     console.log(name);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -14,45 +14,22 @@ modules[0] = function(repo_name) {
       $(".forks").append(""+forks);      
     }).error(function () {
       $(".issues").append("Not available.");
+      $(".stars").append("Not available.");
+      $(".forks").append("Not available.");
 });
-}
-
-modules[1] = function(repo_name) {
-  $.getJSON(GITHUB_API+"repos/"+ORGANIZATION+"/"+repo_name+"/contents/status.txt", 
-    function(data) {
-        status = data.content;
-        var repo_name = repo_name.replace(/[\. ,:-]+/g, "-");
-        if (typeof data.content != 'undefined' ) {
-      	  $(".status").text(atob(data.content));
-        } else {
-      	  $(".status").text("No status available for this repo yet. Check back soon.");
-        }
-      }).error(function () {
-       $(".status").text("No status available for this repo yet. Check back soon.");
-    }
-  );
 }
 
 $(document).ready(function() {
   render_dashboard();
 });
 
-var render_modules = function(projects) {
-  _.map(projects,function(project) {
-      modules[0](project.name);
-  });
+var render_modules = function(name) {
+  modules[0](name);
 }
 
 var render_dashboard = function() {
-  var elements = $(document);
-  var projects = []
-  var content = _.map(elements, function(e) {
-    var ghUrl = $(".github-url").attr("href");
-    var slugIndex = ghUrl.lastIndexOf("/");
-    var name = ghUrl.substr(slugIndex+1);
-    console.log(name);
-    var project = {name: name};
-    projects.push(project);
-  }).join("");
-  render_modules(projects);
+  var ghUrl = $(".github-url").attr("href");
+  var slugIndex = ghUrl.lastIndexOf("/");
+  var name = ghUrl.substr(slugIndex+1);
+  render_modules(name);
 }    

--- a/index.html
+++ b/index.html
@@ -15,16 +15,16 @@ permalink: /
     </header>
     {% for project in site.data.projects %}
       {% if project.status != "Hold" %}
-      {% capture css_id %}{% if project.css_id %}{{ project.css_id }}{% else %}{{ project.name }}{% endif %}{% endcapture %}
-      <article class="dashboard-projects-content" id="{{ css_id }}">
+      <article class="dashboard-projects-content">
         <div>
           <h1>{{project.project}}</h1>
-          <p class="status">{{ project.status }}</p>
+            
+            <p class="status">{% if project.status %}{{ project.status }}{% else %}Unknown{% endif %}</p>
         </div>
-        <div><p class="client">{{ project.client }}</p></div>
+        <div><p class="client">{% if project.client %}{{ project.client }}{% else %}Unknown{% endif %}</p></div>
         <div>
-          <p class="description">{{ project.description }}</p>
-          <p class="dashboard-icon"><a class="github-url" href="{{project.github}}"><i class="icon-github2"></i> See our work &#8594;</a></p>
+          <p class="description">{% if project.description %}{{ project.description }}{% else %}Unknown{% endif %}</p>
+          <p class="dashboard-icon"><a class="github-url" href="{{project.github}}"><i class="icon-github2"></i> See our work on {{ project.project }} &#8594;</a></p>
           <p><a href="http://18f.gsa.gov/tags/{{project.name}}">Read project news &#8594;</a></p>
         </div>
       </article>
@@ -32,5 +32,3 @@ permalink: /
     {% endfor %}
   </section>
 </section>
-<script src="assets/js/underscore.js"></script>
-<script src="assets/js/main.js"></script>

--- a/pages/C2.html
+++ b/pages/C2.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: C2 (Communicart)
+permalink: /project/c2/
+---

--- a/pages/C2.html
+++ b/pages/C2.html
@@ -1,5 +1,5 @@
 ---
 layout: project
-title: C2 (Communicart)
+title: CAP (Communicart)
 permalink: /project/c2/
 ---

--- a/pages/aaa.html
+++ b/pages/aaa.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: Agile Assited Acquisitions
+permalink: /project/aaa/
+---

--- a/pages/aaa.html
+++ b/pages/aaa.html
@@ -1,5 +1,5 @@
 ---
 layout: project
-title: Agile Assited Acquisitions
+title: Agile Assisted Acquisitions
 permalink: /project/aaa/
 ---

--- a/pages/answers.html
+++ b/pages/answers.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: Answers
+permalink: /project/answers/
+---

--- a/pages/api-data-gov.html
+++ b/pages/api-data-gov.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: API.data.gov
+permalink: /project/api-data-gov/
+---

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: Dashboard
+permalink: /project/dashboard/
+---

--- a/pages/developer-program.html
+++ b/pages/developer-program.html
@@ -1,5 +1,5 @@
 ---
 layout: project
 title: /Developer program
-permalink: /dashboard/developer-program/
+permalink: /project/developer-program/
 ---

--- a/pages/doi-extractives-data.html
+++ b/pages/doi-extractives-data.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: DOI Exractives
+permalink: /project/doi-extractives-data/
+---

--- a/pages/doi-extractives-data.html
+++ b/pages/doi-extractives-data.html
@@ -1,5 +1,5 @@
 ---
 layout: project
-title: DOI Exractives
+title: DOI Extractives 
 permalink: /project/doi-extractives-data/
 ---

--- a/pages/fbopen.html
+++ b/pages/fbopen.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: FOIA
+permalink: /project/foia/
+---

--- a/pages/fbopen.html
+++ b/pages/fbopen.html
@@ -1,5 +1,5 @@
 ---
 layout: project
-title: FOIA
-permalink: /project/foia/
+title: FBOpen
+permalink: /project/fbopen/
 ---

--- a/pages/foia-hub.html
+++ b/pages/foia-hub.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: FOIA Hub
+permalink: /project/foia-hub/
+---

--- a/pages/foia.html
+++ b/pages/foia.html
@@ -1,5 +1,5 @@
 ---
 layout: project
 title: FOIA
-permalink: /dashboard/foia/
+permalink: /project/foia/
 ---

--- a/pages/midas.html
+++ b/pages/midas.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: Midas
+permalink: /project/midas/
+---

--- a/pages/myra.html
+++ b/pages/myra.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: My R A
+permalink: /project/myra/
+---

--- a/pages/myusa.html
+++ b/pages/myusa.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: MyUSA
+permalink: /project/myusa/
+---

--- a/pages/openFEC.html
+++ b/pages/openFEC.html
@@ -1,5 +1,5 @@
 ---
 layout: project
-title: OpenFEC
+title: openFEC
 permalink: /project/openFEC/
 ---

--- a/pages/openFEC.html
+++ b/pages/openFEC.html
@@ -1,0 +1,5 @@
+---
+layout: project
+title: OpenFEC
+permalink: /project/openFEC/
+---


### PR DESCRIPTION
Now that we're only doing the API calls on individual project pages the javascript can be much simpler. We rip out the mapping that grabbed the names of all the projects on the page (there's only one now) and scrape the project name out of the GitHub URL. We also now have the status passed in as a class so we can target it with CSS.
