### PR TITLE
IU improvements to project page

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -61,7 +61,6 @@
   name: foia
   github: 
   - 18F/foia
-  - 18F/foia-search
   - 18F/foia-hub
   description: "A new portal to search for and submit FOIA requests and scalable infrastructure for agencies."
   client:

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -10,7 +10,7 @@
 # client: "Main partner (who is paying)"
 # partners: "Other contributing partners, comma separated, as necessary"
 # impact: "The number of users potentially impacted by this service"
-# stage: Choose: Discovery, Alpha, Beta, Live
+# stage: Choose: discovery, alpha, beta, live
 # milestones: "The month and year of major project milestones, such as the date a projects started, began a new stage, recruited new partners, overcame significant bureaucratic hurdles, etc."
 # contact: Email address or URL to preferred feedback mechanism
 # stack: "Stack, technologies"
@@ -30,7 +30,9 @@
   partners:
   impact: "Millions of Americans do not have access to an employee-sponsored retirement plan: more than 50% of full-time and 75% of part-time workers."
   stage: alpha
-  milestones: "August 2014: Project Discovery stage started, September 2014: Project moved from Discovery to Alpha"
+  milestones: 
+  - "August 2014: Project doiscovery stage started"
+  - "September 2014: Project moved from discovery to alpha"
   contact: christopher.cairns@gsa.gov
   stack: "HTML, CSS, JavaScript, Jekyll"
   team: "chrisc, manger"
@@ -83,7 +85,8 @@
   partners:
   impact: "318 million Americans are affected every 2 years by each election"
   stage: discovery
-  milestones: "June 2014: Project Discovery stage started"
+  milestones: 
+  - "June 2014: Project Discovery stage started"
   contact: 18F/FEC/issues 
   stack:
   team:
@@ -100,7 +103,9 @@
   partners:
   impact: "Revenue from the sale of natural resources on Federal lands totaled $97.5 billion between 2003 to 2013."
   stage: alpha
-  milestones: "July 2014: 18F began work on project, September 2014: Alpha site launched"
+  milestones:
+  - "July 2014: 18F began work on project"
+  - "September 2014: alpha site launched"
   contact: christopher.cairns@gsa.gov
   stack: JavaScript, Jekyll
   team:
@@ -160,7 +165,7 @@
   links: http://gsa.gov/oasis
   status:
 - project: "API.data.gov"
-  name: "api.data.gov"
+  name: "api-data-gov"
   github: 
   - http://github.com/18f/api.data.gov
   description: "A hosted, shared-service that is free to agencies that provides an API key, analytics, and proxy solution for government web services."

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -70,6 +70,8 @@
 <link href="{{ site.baseurl }}/assets/css/fonts.css" rel="stylesheet">
 <link href="{{ site.baseurl }}/assets/css/normalize.css" rel="stylesheet">
 <link href="{{ site.baseurl }}/assets/css/styles.css" rel="stylesheet">
+<!-- Remove FontAwesome later, add specific icons to cleaned 18F font instead -->
+<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 
 <!-- JS
 ================================================== -->

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -12,55 +12,60 @@ layout: bare
       - the css_id variable captured above is either project.name or project.css_id
         if the latter exists as a field.
     -->
-    <h1>{{ page.title }} <span class="status {{ project.stage }}">{% if project.stage %}{{ project.stage }}{% else %}unknown{% endif %}</span></h1>
-    <p class="description">{{ project.description }}</p>
-    <section class="dash-info-area">
+    <section class="dashboard-project">
+      <nav><a href="{{ site.baseurl }}/">&#10094;&#10094; back to main dashboard</a></nav>
+      <h1>{{ page.title }} <span class="status {{ project.stage }}">{% if project.stage %}{{ project.stage }}{% else %}unknown{% endif %}</span></h1>
+      <p>{{ project.description }}</p>
+      <p>Contact: 
+        {% if project.contact contains '@' %}
+          <a href="mailto:{{project.contact}}">{{project.contact}}</a>
+        {% else %}
+          <a href="https://www.github.com/{{project.contact}}">{{project.contact}}</a>
+        {% endif %}
+      </p>
+    </section>
+    <section class="dashboard-info-area">
       <div>
-        <div>
-          <h1>issues</h1>
-          <p class="issues"></p>
-        </div>
         <div class="dash-info-long">
           <h1>impact</h1>
           <p>{{ project.impact }}</p>
         </div>
-      </div>
-      <div>
-        <div>
-          <h1>code</h1>
-            <p class="dashboard-icon"><a class="github-url" href="https://github.com/{{ project.github | first }}"><i class="icon-github2"></i></a></p>
-          {% if project.github.size > 2 %}
-            <p>Other repos in this project</p>
-            {% for url in project.github  | offset: 1 %}
-              <p class=""><a class="" href="https://github.com/{{url}}">{{ url  }}</a></p>
-            {% endfor %}
-          {% endif %}
-        </div>
-        <div>
-          <h1>partners</h1>
-          <p>{{ project.partners }}</p>
-        </div>
-        <div>
-          <h1>licenses</h1>
-          <p>{{ project.licenses }}</p>
+        <div class="dash-info-long">
+          <h1>partner(s)</h1>
+          <p>{{ project.client }}</p>
         </div>
       </div>
       <div>
-        <div>
-          <h1>stars</h1>
-          <p class="stars"></p>
+        <div class="dashboard-code">
+          <h1 class="dashboard-code-head">code</h1>
+          {% for url in project.github %}
+          <div>
+            <h1>
+              {% if project.github | first %}
+              <i class="fa fa-github"></i> <a class="github-url" href="https://github.com/{{ url }}">{{ url }}</a>
+              {% else %}
+              <i class="icon-github2"></i> <a href="https://github.com/{{ url }}">{{ url }}</a>
+              {% endif %}
+            </h1>
+            <ul>
+              <li class="issues"><i class="fa fa-exclamation-circle"></i> Issues: </li>
+              <li class="stars"><i class="fa fa-star"></i> Stars: </li>
+              <li class="forks"><i class="fa fa-code-fork"></i> Forks: </li>
+              {% if project.licenses != null %}
+                <li><i class="fa fa-legal"></i> License: {{ project.licenses }}</li>
+              {% endif %}
+            </ul>
+          </div>
+          {% endfor %}
         </div>
-        <div>
-          <h1>forks</h1>
-          <p class="forks"></p>
-        </div>
-        <div>
-          <h1>contact</h1>
-          <p class="dashboard-icon"><a class="github-url" href="mailto:{{project.contact}}"><i class="icon-email"></i></a></p>
+        <div class="dash-info-long">
+          <h1>milestones</h1>
+          {% for item in project.milestones %}
+          <p>{{ item }}</p>
+          {% endfor %}
         </div>
       </div>
     </section>
-  
   {% endif %}
 {% endfor %}
 <script src="{{site.baseurl}}/assets/js/underscore.js"></script>

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -761,15 +761,61 @@ $tiniest: new-breakpoint(max-width 390px);
 	background-color: $red;
 }
 
-.dash-info-area {
-	@include span-columns(12);
-	> div {
-		@include span-columns(4 of 12);
+.dashboard-project {
+	nav {
+		font-size: 0.8em;
+		margin-bottom:42px;
+		a {
+			text-decoration: none;
+			color: $dark-gray;
+			&:hover, &:focus {
+				text-decoration: underline;
+				color: $red;
+			}
+		}
+	}
+	h1 {
+		padding-top: 5px;
+		border-top: 1px solid $medium-gray;
+	}
+	p {
+		@include span-columns(9);
+		font-size: 1.2em;
+		line-height: 1.4em;
+		margin-top: 15px;
+		margin-bottom: 0;
+		a:hover, a:focus {
+			text-decoration: underline;
+		}
+	}
+	p + p {
+		font-size: 0.9em;
+		margin-bottom: 50px;
+	}
+}
+
+.dashboard-info-area {
+	@include span-columns(9 of 9);
+	> div:nth-of-type(1) {
+		@include span-columns(3 of 9);
 		> div {
 			background-color: lighten($blue, 30%);
 			border: 8px solid lighten($blue, 30%);
 			padding: 10px;
-			margin-bottom: 10px;
+			margin-bottom: 23px;
+			&:hover, &:focus {
+				background-color: lighten($blue, 20%);
+				border: 8px solid $green;
+			}
+		}
+	}
+	> div:nth-of-type(2) {
+		@include span-columns(6 of 9);
+		> div {
+			background-color: lighten($blue, 30%);
+			border: 8px solid lighten($blue, 30%);
+			padding: 10px;
+			margin-bottom: 23px;
 			&:hover, &:focus {
 				background-color: lighten($blue, 20%);
 				border: 8px solid $green;
@@ -781,9 +827,6 @@ $tiniest: new-breakpoint(max-width 390px);
 		i {
 			font-size: 1em;
 		}
-	}
-	i {
-		font-size: 3em;
 	}
 	p {
 		margin-bottom: 0;
@@ -798,6 +841,23 @@ $tiniest: new-breakpoint(max-width 390px);
 		text-align: left;
 		font-style: italic;
 		line-height: 1em;
+	}
+}
+.dashboard-code {
+	.dashboard-code-head{
+		padding-bottom: 15px;
+	}
+	ul {
+		margin-top: 7px;
+		li {
+			display: inline-block;
+			font-size: 1em;
+			margin-bottom: 16px;
+			margin-left: 15px;
+			i {
+				font-size: 1em;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
- Cleans up layout of project pages in general and brings it closer to the design of the dashboard homepage. Also adds a 'back' nav to improve basic usability.
- Condenses code-related info into one block. This makes those data easier to understand, and also can expand automagically to however many repos are associated with each project.
  ![screenshot 2014-10-08 20 18 52](https://cloud.githubusercontent.com/assets/4827522/4570666/078ff86e-4f63-11e4-93a0-7335db5812ea.png)
- Moves license info into code block and associates it with each repo. This will cover the use case that different repos may have different licenses. The license datapoint also only appears if that info is in the yml file (compare the screenshot below to the one above).
  ![screenshot 2014-10-08 20 20 26](https://cloud.githubusercontent.com/assets/4827522/4570675/3bed5f66-4f63-11e4-8b57-e7b987cda951.png)
- Turns milestones into arrays so that they can be styled as lists instead of one text block.
  ![screenshot 2014-10-08 20 21 42](https://cloud.githubusercontent.com/assets/4827522/4570685/6e94547e-4f63-11e4-9520-7172f1f0a52f.png)
- Adds a conditional filter to the contact block so that if that string has an '@' it will add a `mailto` link. If there is no @, it will link to a normal url.
- Adds a link to the FontAwesome hosted CDN in head to get nice icons for the code links. If we like this approach, we should add those icons to our 18F font instead of pulling from the CDN.
