### PR TITLE
Fixes #80, contact links should function as expected

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -17,7 +17,8 @@ layout: bare
       <h1>{{ page.title }} <span class="status {{ project.stage }}">{% if project.stage %}{{ project.stage }}{% else %}unknown{% endif %}</span></h1>
       <p>{{ project.description }}</p>
       <p>Contact:
-        {% if project.contact contains '@' %}
+        {% capture contact %}{{ project.contact }}{% endcapture %}
+        {% if contact contains '@' %}
           <a href="mailto:{{project.contact}}">{{project.contact}}</a>
         {% else %}
           <a href="https://www.github.com/{{project.contact}}">{{project.contact}}</a>


### PR DESCRIPTION
Not totally sure why _this_ worked but @meiqimichelle's didn't. All I did was capture the contact variable before running it through the conditional. Apparently Jekyll makes a distinction between `object.variable` and `variable`. Fixes #80.
