### PR TITLE
Adds stage overview stats to top of homepage. Links stage description pa...

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -306,7 +306,7 @@
   partners:
   - "Early adopters ready for launch include Small Business Administration, Department of Labor, and GSA."
   impact: "The millions of Americans who conduct online transactions with U.S. government."
-  stage: Alpha
+  stage: alpha
   milestones:
   - "June 2014: 18F began work on project"
   - "September 2014: Alpha delivered to clients and user testing started"

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -771,6 +771,41 @@ $tiniest: new-breakpoint(max-width 390px);
 	background-color: $red;
 }
 
+.dashboard-overview,
+.dashboard-overview-numbers {
+	text-align: center;
+	li {
+		@include span-columns(3 of 12);
+		font-family: $header-font-family;
+		font-size: 2.5em;
+		padding: 10px;
+		.status-description {
+			color: white;
+			line-height: 1.1em;
+			font-size: 0.47em;
+		}
+	}
+	.status {
+		float: none;
+		margin-right: 10px;
+	}
+}
+
+.dashboard-overview-numbers {
+	li {
+		font-family: $base-font-family;
+		font-weight: 600;
+		font-size: 4em;
+		margin-top: -55px;
+  		-webkit-text-stroke: 1px white;
+	  	text-shadow:
+	   -1px -1px 0 white,  
+	    1px -1px 0 white,
+	   -1px  1px 0 white,
+	    1px  1px 0 white;
+	}
+}
+
 .dashboard-status-definitions {
 	> div:nth-of-type(1) {
 		&:hover, &:focus {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,25 @@ permalink: /
 
 <section class="dashboard">
   <h1>{{page.title}}</h1>
-  <p class="lead">We are building digital services for the American people. Follow our progress and get involved here.</p>
+  <p class="lead">We are building digital services for the American people. Follow our progress and get involved here. Learn about our project development stages <a href="{{ site.baseurl }}/stages/">here</a>.</p>
+  <ul class="dashboard-overview">
+    <li class="discovery"><span class="status">discovery</span>
+      <p class="status-description">User needs are researched and identified.</p>
+    </li>
+    <li class="alpha"><span class="status alpha">alpha</span>
+      <p class="status-description">A core service is built to meet the main user needs.</p>
+    </li>
+    <li class="beta"><span class="status beta">beta</span>
+      <p class="status-description">The service is improved, then tested in public.</p></li>
+    <li class="live"><span class="status live">live</span>
+      <p class="status-description">The service is public and works well.</p></li>
+  </ul>
+  <ul class="dashboard-overview-numbers">
+    <li>3</li>
+    <li>4</li>
+    <li>3</li>
+    <li>2</li>
+  </ul>
   <section class="dashboard-projects">
     <div>
       {% for project in site.data.projects %}

--- a/stages.html
+++ b/stages.html
@@ -6,7 +6,7 @@ permalink: /stages/
 
 <section class="dashboard">
   <h1>{{page.title}}</h1>
-  <p class="lead">This is where the intro to this page will be.</p>
+  <p class="lead">Right now, this text is borrowed from <a href="https://www.gov.uk/transformation">gov.uk's excellent work in this area</a>. 18F is working on its own version now, and will update soon!</p>
   <nav><a href="{{ site.baseurl }}/">&#10094;&#10094; back to main dashboard</a></nav>
   <section class="dashboard-projects">
     <div>
@@ -15,7 +15,7 @@ permalink: /stages/
           <h1><span class="status discovery">discovery</span></h1>
         </div>
         <div>
-          <p>This is where the description of this stage will be.</p>
+          <p>Find out what your users need, what to measure and what your constraints are.</p>
         </div>
       </article>
       <article class="dashboard-status-definitions">
@@ -23,7 +23,7 @@ permalink: /stages/
           <h1><span class="status alpha">alpha</span></h1>
         </div>
         <div>
-          <p>This is where the description of this stage will be.</p>
+          <p>Build a prototype, test it with users and learn from it.</p>
         </div>
       </article>
       <article class="dashboard-status-definitions">
@@ -31,7 +31,7 @@ permalink: /stages/
           <h1><span class="status beta">beta</span></h1>
         </div>
         <div>
-          <p>This is where the description of this stage will be.</p>
+          <p>Scaling up and going public.</p>
         </div>
       </article>
       <article class="dashboard-status-definitions">
@@ -39,7 +39,7 @@ permalink: /stages/
           <h1><span class="status live">live</span></h1>
         </div>
         <div>
-          <p>This is where the description of this stage will be.</p>
+          <p>Learn how to continuously improve your live service.</p>
         </div>
       </article>
     </div>


### PR DESCRIPTION
- Adds stage overview stats to top of homepage (not live numbers yet -- couldn't get the Jekyll worked out to get it to read counts of instances of values in our project file)
- Links stage description page to homepage. This is pretty basic still in this iteration -- just a static link in the intro paragraph.
- Inserts text from gov.uk into status description page for attribution.

Screenshot:
![screenshot 2014-10-14 17 21 45](https://cloud.githubusercontent.com/assets/4827522/4638864/b34e8f06-5401-11e4-8208-8f0d4ea5969d.png)
