### PR TITLE
Maybe it's simply capitalization?

### DIFF
--- a/pages/project/C2.html
+++ b/pages/project/C2.html
@@ -1,5 +1,5 @@
 ---
 layout: project
 title: "Common Acquisition Platform Tools"
-permalink: /project/c2/
+permalink: /project/C2/
 ---


### PR DESCRIPTION
Similar to @meiqimichelle the name of the project, html file, and permalink must be the same. Maybe for some reason gh-pages is picky on capitalization in a way that the WEBrick and nginx servers aren't and that's why it would work locally.
