### PR TITLE
adds _config.yml to gitignore and copies an example file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 *.log
 /.sass-cache/
+_config.yml

--- a/_config.yml.sample
+++ b/_config.yml.sample
@@ -1,0 +1,12 @@
+markdown: kramdown
+
+title: 18F Digital Services Delivery
+description: "18F builds effective, user-centric digital services focused on the interaction between government and the people and businesses it serves."
+
+sass:
+  sass_dir: assets/_sass
+
+gems: [bourbon]
+
+baseurl: /dashboard
+#baseurl: localhost:4000


### PR DESCRIPTION
For a future where we deploy to some place other than GitHub pages. See also: changes to the `_config.yml` file in the `staging` and `production` branches
