### PR TITLE
Cleans stages and project pages

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -53,7 +53,7 @@
   name: peacecorps-site
   github:
   - 18F/peacecorps-site
-  description: "A redesign of the peacecorps.gov, offering a new, user-focused experience for users."
+  description: "A redesign of peacecorps.gov, offering a new, user-focused experience for users."
   partner:
   - "Peace Corps"
   partners:
@@ -232,7 +232,7 @@
   - "Regulations.gov"
   - USDA
   partners:
-  stage: live
+  stage: beta
   impact: "2,100 API users and 42 million API requests served so far"
   milestones:
   contact:

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -28,7 +28,7 @@ layout: bare
       {% assign tags = blog | split: ',' %}
       {% if tags.size > 0 %}
         <p>
-          Blog posts tagged /
+          <i class="fa fa-tags"></i>  /
           <span class="blog-tags" itemprop="keywords">
             {% for t in tags %}
               <a href="http://18f.gsa.gov/tags/{{ t }}">{{ t }}</a>
@@ -86,9 +86,9 @@ layout: bare
           <div class="{{ repo_name | replace: ".", "-" }} repo">
             <h1>
               {% if project.github | first %}
-              <i class="fa fa-github"></i> <a class="github-url" href="https://github.com/{{ url }}">{{ url }}</a>
+              <i class="fa fa-github-alt"></i> <a class="github-url" href="https://github.com/{{ url }}">{{ url }}</a>
               {% else %}
-              <i class="icon-github2"></i> <a href="https://github.com/{{ url }}">{{ url }}</a>
+              <i class="fa fa-github-alt"></i> <a href="https://github.com/{{ url }}">{{ url }}</a>
               {% endif %}
             </h1>
             <ul>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -3,14 +3,11 @@ layout: bare
 ---
 {% for project in site.data.projects %}
   {% if project.project == page.title %}
-    {% capture css_id %}{% if project.css_id %}{{ project.css_id }}{% else %}{{ project.name }}{% endif %}{% endcapture %}
     <!--
       Do the other things here. Basically, we now have two objects inside this loop:
       - the page object which has anything in a page's front matter
       - the project object, which is the project inside _data/projects.yml
         whose `project` field matches thie page's `title` field.
-      - the css_id variable captured above is either project.name or project.css_id
-        if the latter exists as a field.
     -->
     <section class="dashboard-project">
       <nav><a href="{{ site.baseurl }}/">&#10094;&#10094; back to main dashboard</a></nav>
@@ -27,69 +24,66 @@ layout: bare
           {% endif %}
         {% endfor %}
       </p>
+      {% capture blog %}{{ project.blog }}{% endcapture %}
+      {% assign tags = blog | split: ',' %}
+      {% if tags.size > 0 %}
+        <p>
+          Blog posts tagged /
+          <span class="blog-tags" itemprop="keywords">
+            {% for t in tags %}
+              <a href="http://18f.gsa.gov/tags/{{ t }}">{{ t }}</a>
+              /
+            {% endfor %}
+          </span>
+        </p>
+      {% endif %}
     </section>
 
     <section class="dashboard-info-area">
       <div>
+        <!-- impact -->
         {% if project.impact %}
-          <div class="dash-info-long">
-            <h1>impact</h1>
+          <div>
+            <h1><i class="fa fa-chevron-right"></i> impact</h1>
             <p>{{ project.impact }}</p>
           </div>
         {% endif %}
 
+        <!-- partners -->
         {% if project.partner %}
-        <div class="dash-info-long">
-          {% if project.partner.size > 1 %}
-            <h1>partners</h1>
-          {% else %}
-            <h1>partner</h1>
-          {% endif %}
-          <ul>
-          {% for agency in project.partner %}
-            <li>{{ agency }}</li>
-          {% endfor %}
-        </ul>
-          <p>{{ project.partners | join: ', '}}</p>
-        </div>
+          <div>
+            {% if project.partner.size > 1 %}
+              <h1><i class="fa fa-chevron-right"></i> partners</h1>
+            {% else %}
+              <h1><i class="fa fa-chevron-right"></i> partner</h1>
+            {% endif %}
+            <ul>
+              {% for agency in project.partner %}
+                <li>{{ agency }}</li>
+              {% endfor %}
+            </ul>
+            <p>{{ project.partners | join: ', '}}</p>
+          </div>
         {% endif %}
 
-        {% capture blog %}{{ project.blog }}{% endcapture %}
-          {% assign tags = blog | split: ',' %}
-          {% if tags.size > 0 %}
-          <div class="dash-info-long">
-            <p>
-              Blog posts tagged /
-              <span class="blog-tags" itemprop="keywords">
-                {% for t in tags %}
-                  <a href="http://18f.gsa.gov/tags/{{ t }}">{{ t }}</a>
-                  /
-                {% endfor %}
-              </span>
-            </p>
+        <!-- milestones -->
+        {% if project.milestones %}
+          <div>
+            <h1><i class="fa fa-chevron-right"></i> milestones</h1>
+            <ul>
+              {% for item in project.milestones %}
+              <li>{{ item }}</li>
+              {% endfor %}
+            </ul>
           </div>
-          {% endif %}
-<!--
-        {% if project.team.size > 0 %}
-        <div class="dash-info-long">
-           <h1>Team:</h1>
-           <ul class="staff">
-             {% capture team %}{{ project.team }}{% endcapture %}
-             {% assign team = team | split: ',' %}
-             {% for name in team %}
-              <li class="{{ name | replace: ' ', '' }}"></li>
-             {% endfor %}
-           </ul>
-         </div>
         {% endif %}
--->
-      </div>
-      <div>
+
+        <!-- code -->
         <div class="dashboard-code">
-          <h1 class="dashboard-code-head">code</h1>
+          <h1><i class="fa fa-chevron-right"></i> code</h1>
           {% for url in project.github %}
           {% capture repo_name %}{{ url | remove: "18F/" }}{% endcapture %}
-          <div class="{{ repo_name | replace: ".", "-" }}">
+          <div class="{{ repo_name | replace: ".", "-" }} repo">
             <h1>
               {% if project.github | first %}
               <i class="fa fa-github"></i> <a class="github-url" href="https://github.com/{{ url }}">{{ url }}</a>
@@ -110,16 +104,20 @@ layout: bare
           </div>
           {% endfor %}
         </div>
-
-        {% if project.milestones %}
-        <div class="dash-info-long">
-          <h1>milestones</h1>
-          {% for item in project.milestones %}
-          <p>{{ item }}</p>
-          {% endfor %}
-        </div>
+<!--
+        {% if project.team.size > 0 %}
+        <div>
+           <h1>Team:</h1>
+           <ul class="staff">
+             {% capture team %}{{ project.team }}{% endcapture %}
+             {% assign team = team | split: ',' %}
+             {% for name in team %}
+              <li class="{{ name | replace: ' ', '' }}"></li>
+             {% endfor %}
+           </ul>
+         </div>
         {% endif %}
-        
+-->
       </div>
     </section>
   {% endif %}

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -729,7 +729,6 @@
 		}
 	}
 	p {
-		line-height: 1.2em;
 		margin-bottom: 8px;
 		a:hover, a:focus {
 			text-decoration: underline;
@@ -939,7 +938,8 @@
 		line-height: 1.4em;
 		margin-top: 15px;
 		margin-bottom: 0;
-		a:hover, a:focus {
+		a:hover,
+		a:focus {
 			text-decoration: underline;
 		}
 	}

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -926,7 +926,6 @@
 			}
 		}
 	}
-
 }
 
 .dashboard-project {
@@ -946,6 +945,9 @@
 	}
 	p + p {
 		font-size: 0.9em;
+	}
+	p:last-of-type {
+		margin-top: 6px;
 		margin-bottom: 50px;
 	}
 }
@@ -953,35 +955,12 @@
 .dashboard-info-area {
 	@include span-columns(9 of 9);
 	> div:nth-of-type(1) {
-		@include span-columns(3 of 9);
-		@include media($tiny) {
-			@include span-columns(9 of 9);
-		}
-		> div {
-			background-color: lighten($blue, 30%);
-			border: 8px solid lighten($blue, 30%);
-			padding: 10px;
-			margin-bottom: 23px;
-			&:hover, &:focus {
-				background-color: lighten($blue, 20%);
-				border: 8px solid $green;
-			}
-		}
-	}
-	> div:nth-of-type(2) {
 		@include span-columns(6 of 9);
 		@include media($tiny) {
 			@include span-columns(9 of 9);
 		}
 		> div {
-			background-color: lighten($blue, 30%);
-			border: 8px solid lighten($blue, 30%);
-			padding: 10px;
 			margin-bottom: 23px;
-			&:hover, &:focus {
-				background-color: lighten($blue, 20%);
-				border: 8px solid $green;
-			}
 		}
 	}
 	h1 {
@@ -992,48 +971,43 @@
 	}
 	p {
 		margin-bottom: 0;
-		text-align: center;
-		font-size:	3em;
-	}
-}
-
-.dash-info-long {
-	p {
-		font-size: 1em;
-		padding-top: 5px;
-		text-align: left;
-		font-style: italic;
-		line-height: 1em;
+		padding-top: 7px;
+		padding-left: 20px;
 	}
 	ul {
 		list-style-type: square;
-		padding-left: 20px;
+		padding-left: 40px;
 		padding-top: 7px;
 		padding-bottom: 7px;
-		li {
-			line-height: 1em;
-		}
+	}
+	ul + p {
+		padding-top: 0;
+		font-style: italic;
+		color: $medium-gray;
 	}
 }
 
 .dashboard-code {
-	.dashboard-code-head{
-		padding-bottom: 15px;
-	}
-	ul {
-		margin-top: 7px;
-		margin-bottom: 16px;
-		li {
-			display: inline-block;
-			font-size: 1em;
-			margin-left: 15px;
-			i {
-				font-size: 1em;
-			}
-		}
+	> h1:first-of-type {
+		padding-bottom: 13px;
 	}
 }
 
+.repo {
+	padding-left: 20px;
+	h1 {
+		font-family: $base-font-family;
+		font-size: 1.1em;
+	}
+	ul {
+		padding-left: 0;
+	  margin-bottom: 7px;
+	}
+	li {
+		display: inline-block;
+		margin-left: 20px;
+	}
+}
 
 // 404
 //********************************************************

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -737,6 +737,15 @@
 	}
 }
 
+.dashboard-status-definitions {
+	> div:nth-of-type(2) {
+		@include span-columns(8);
+		@include media($tiny) {
+			@include span-columns(12);
+		}
+	}
+}
+
 .status {
 	padding: 5px 10px 5px 10px;
 	margin-top: -5px;
@@ -903,6 +912,7 @@
 	}
 }
 
+.dashboard-stages,
 .dashboard-project {
 	nav {
 		font-size: 0.8em;
@@ -916,6 +926,10 @@
 			}
 		}
 	}
+
+}
+
+.dashboard-project {
 	h1 {
 		padding-top: 5px;
 		border-top: 1px solid $medium-gray;

--- a/index.html
+++ b/index.html
@@ -17,19 +17,19 @@ permalink: /
     <a href="{{ site.baseurl }}/stages/">
       <li class="alpha"><span class="status alpha">alpha</span>
         <p class="status-description">A core service is built to meet the main user needs.</p>
-        <p class="dashboard-overview-numbers">4</p>
+        <p class="dashboard-overview-numbers">5</p>
       </li>
     </a>
     <a href="{{ site.baseurl }}/stages/">
       <li class="beta"><span class="status beta">beta</span>
         <p class="status-description">The service is improved, then tested in public.</p>
-        <p class="dashboard-overview-numbers">2</p>
+        <p class="dashboard-overview-numbers">3</p>
       </li>
     </a>
     <a href="{{ site.baseurl }}/stages/">
       <li class="live"><span class="status live">live</span>
         <p class="status-description">The service is public and works well.</p>
-        <p class="dashboard-overview-numbers">3</p>
+        <p class="dashboard-overview-numbers">1</p>
       </li>
     </a>
   </ul>
@@ -45,23 +45,29 @@ permalink: /
           <div>
             <p>{% if project.description %}{{ project.description }}{% else %}Project description coming soon.{% endif %}</p>
           </div>
+
           <div>
-           <p>{% if project.partner.size == 1 %}Partner: {%else%}Partners: {%endif%}{% if project.partner %}<strong>{{ project.partner | join: ', ' }}</strong>{% else %}Coming soon{% endif %}</p>
-          <p>Code: <a class="github-url" href="https://github.com/{{project.github.first}}"> see our work on Github &#8594;</a></p>
-          {% capture blog %}{{ project.blog }}{% endcapture %}
-          {% assign tags = blog | split: ',' %}
-          {% if tags.size > 0 %}
-            <p>
-              Blog posts tagged /
-              <span class="blog-tags" itemprop="keywords">
-                {% for t in tags %}
-                  <a href="http://18f.gsa.gov/tags/{{ t }}">{{ t }}</a>
-                  /
-                {% endfor %}
-              </span>
-            </p>
-          {% endif %}
-          <p>Details: <a href="{{ site.baseurl }}/project/{{ project.name }}">all the metrics we track on this project &#8594;</a></p>
+
+            <p>{% if project.partner.size == 1 %}Partner: {%else%}Partners: {%endif%}{% if project.partner %}<strong>{{ project.partner | join: ', ' }}</strong>{% else %}Coming soon{% endif %}</p>
+
+            <p><i class="fa fa-github-alt"></i> / <a class="github-url" href="https://github.com/{{project.github.first}}">Our work on Github</a> / </p>
+            
+            <p><i class="fa fa-bar-chart"></i> / <a href="{{ site.baseurl }}/project/{{ project.name }}">All project metrics</a> / </p>
+
+            {% capture blog %}{{ project.blog }}{% endcapture %}
+            {% assign tags = blog | split: ',' %}
+            {% if tags.size > 0 %}
+              <p>
+                <i class="fa fa-tags"></i> /
+                <span class="blog-tags" itemprop="keywords">
+                  {% for t in tags %}
+                    <a href="http://18f.gsa.gov/tags/{{ t }}">{{ t }}</a>
+                    /
+                  {% endfor %}
+                </span>
+              </p>
+            {% endif %}
+
           </div>
         </article>
         {% endif %}

--- a/stages.html
+++ b/stages.html
@@ -6,7 +6,7 @@ permalink: /stages/
 
 <section class="dashboard">
   <h1>{{page.title}}</h1>
-  <p class="lead">These are the stages of agile development and human-centered design that we use at 18F to build products and services. We are still drafting our definitions and guidelines, so if you want to learn more, we recommend <a href="https://www.gov.uk/service-manual">GOV.uk's excellent work in this area</a>.</p>
+  <p class="lead">These are the agile development and human-centered design stages that we use at 18F to build products and services. We are still drafting our definitions and guidelines, so if you want to learn more, we recommend <a href="https://www.gov.uk/service-manual">GOV.UK's excellent work in this area</a>.</p>
   <nav><a href="{{ site.baseurl }}/">&#10094;&#10094; back to main dashboard</a></nav>
   <section class="dashboard-projects">
     <div>

--- a/stages.html
+++ b/stages.html
@@ -4,44 +4,45 @@ title: Project Stage Definitions
 permalink: /stages/
 ---
 
-<section class="dashboard">
+<section class="dashboard dashboard-stages">
+  <nav><a href="{{ site.baseurl }}/">&#10094;&#10094; back to main dashboard</a></nav>
   <h1>{{page.title}}</h1>
   <p class="lead">These are the agile development and human-centered design stages that we use at 18F to build products and services. We are still drafting our definitions and guidelines, so if you want to learn more, we recommend <a href="https://www.gov.uk/service-manual">GOV.UK's excellent work in this area</a>.</p>
-  <nav><a href="{{ site.baseurl }}/">&#10094;&#10094; back to main dashboard</a></nav>
+
   <section class="dashboard-projects">
     <div>
-      <article class="dashboard-status-definitions">
+      <div class="dashboard-status-definitions">
         <div>
           <h1><span class="status discovery">discovery</span></h1>
         </div>
         <div>
-          <p>Who are your users and what are their true needs? In this phase, you will start to answer those questions so that you can plan to build a useful product. Conducting primary research (interviewing and observing the actual users) is ideal. In addition to the users’ needs, you will explore other stakeholders’ needs, such as specific client or policy requirements. <a href="https://www.gov.uk/service-manual/phases/discovery.html">Learn more.</a></p>
+          <p><strong>Who are your users and what are their true needs?</strong> In this phase, you will start to answer those questions so that you can plan to build a useful product. Conducting primary research (interviewing and observing the actual users) is ideal. In addition to the users’ needs, you will explore other stakeholders’ needs, such as specific client or policy requirements. <a href="https://www.gov.uk/service-manual/phases/discovery.html">Learn more.</a></p>
         </div>
-      </article>
-      <article class="dashboard-status-definitions">
+      </div>
+      <div class="dashboard-status-definitions">
         <div>
           <h1><span class="status alpha">alpha</span></h1>
         </div>
         <div>
-          <p>Build one or more prototypes based on the research from the Discovery phase. Test the prototypes with small groups of actual users. Work closely with designers and developers to implement changes based on user feedback. Frequently release iterations to a small group of testers. Discover technical and design needs during this process (e.g., choose and test initial tech stack). <a href="https://www.gov.uk/service-manual/phases/alpha.html">Learn more.</a></p>
+          <p><strong>Build one or more prototypes based on the research from the Discovery phase.</strong> Test the prototypes with small groups of actual users. Work closely with designers and developers to implement changes based on user feedback. Frequently release iterations to a small group of testers. Discover technical and design needs during this process (e.g., choose and test initial tech stack). <a href="https://www.gov.uk/service-manual/phases/alpha.html">Learn more.</a></p>
         </div>
-      </article>
-      <article class="dashboard-status-definitions">
+      </div>
+      <div class="dashboard-status-definitions">
         <div>
           <h1><span class="status beta">beta</span></h1>
         </div>
         <div>
-          <p>Stage and test a live, robust demo on the public web for use by a subset of the target audience. Implement changes based on user behavior and feedback. Resolve policy compliance or technical integration issues. Define and then validate statistically significant metrics for improvement. <a href="https://www.gov.uk/service-manual/phases/beta.html">Learn more.</a></p>
+          <p><strong>Stage and test a live, robust demo on the public web for use by a subset of the target audience.</strong> Implement changes based on user behavior and feedback. Resolve policy compliance or technical integration issues. Define and then validate statistically significant metrics for improvement. <a href="https://www.gov.uk/service-manual/phases/beta.html">Learn more.</a></p>
         </div>
-      </article>
-      <article class="dashboard-status-definitions">
+      </div>
+      <div class="dashboard-status-definitions">
         <div>
           <h1><span class="status live">live</span></h1>
         </div>
         <div>
-          <p>Open the site to all users. Necessary security, performance, and policy requirements have been met, including Authority to Operate (ATO). Continue to iteratively improve the service based on analytics and user feedback. <a href="https://www.gov.uk/service-manual/phases/live.html">Learn more.</a></p>
+          <p><strong>Open the site to all users.</strong> Necessary security, performance, and policy requirements have been met, including Authority to Operate (ATO). Continue to iteratively improve the service based on analytics and user feedback. <a href="https://www.gov.uk/service-manual/phases/live.html">Learn more.</a></p>
         </div>
-      </article>
+      </div>
     </div>
   </section>
 </section>


### PR DESCRIPTION
- Minor text edits to stages intro text (including GOV.uk --> GOV.UK)(it seems like this is what they use on their site)
- Gave a bit more space to stages text and weighted intro line
- Moved stages page 'back' link to the top of page to match style on projects pages
- Cleaned HTML on projects pages (in particular removed unused css_id jekyll statements)
- Simplified and cleaned projects page layout, a la below:

![screenshot 2014-10-23 15 31 54](https://cloud.githubusercontent.com/assets/4827522/4762650/d4fbb9a8-5b04-11e4-94ce-c2f1c1b55d6e.png)
