### PR TITLE
Update with more recent api.data.gov metrics

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -233,7 +233,7 @@
   - USDA
   partners:
   stage: beta
-  impact: "2,100 API users and 42 million API requests served so far"
+  impact: "2,800 API users and 66 million API requests served since July 2013"
   milestones:
   contact:
   - api.data.gov@gsa.gov


### PR DESCRIPTION
In our last round of metric updates, we also added a "since" date to the
numbers mean a little more, so I made that same change here. Let me know
if anyone feels differently.

(and we have plans to API-ify these metrics, so at some point, we might
have a better way to maintain these).
