### PR TITLE
Fix displaying stats for non-18F github repos

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -82,7 +82,7 @@ layout: bare
         <div class="dashboard-code">
           <h1><i class="fa fa-chevron-right"></i> code</h1>
           {% for url in project.github %}
-          {% capture repo_name %}{{ url | remove: "18F/" }}{% endcapture %}
+          {% capture repo_name %}{{ url | split: "/" | last }}{% endcapture %}
           <div class="{{ repo_name | replace: ".", "-" }} repo">
             <h1>
               {% if project.github | first %}


### PR DESCRIPTION
Namely, this fixes the NREL/api-umbrella stats on the api.data.gov page.

I think this should fix #144 and make #145 defunct.

The stats were being pulled correctly by the javascript code, they just
weren't showing up on the page, since it couldn't find the expected
selector (which expected just the repo name, and no organization name).
This update should ensure that just the repo name is used when
generating the elements, regardless of organization name.
