### PR TITLE
Status display color schemes demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.log
 /.sass-cache/
 _config.yml
+.*.swp

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -21,12 +21,12 @@
 
 .stage-bug {
 	display: block;
-  background: #f3f3f3;
-  color: #333;
-  border: 1px solid #d9d9d9;
-  border-top: none;
-  text-align: center;
-  padding: .5em 0;
+	background: #f3f3f3;
+	color: #333;
+	border: 1px solid #d9d9d9;
+	border-top: none;
+	text-align: center;
+	padding: .5em 0;
 }
 
 // Extends
@@ -752,11 +752,11 @@
 .status {
 	padding: 5px 10px 5px 10px;
 	margin-top: -5px;
-	color: white;
+	color: black;
 	font-size: .7em;
 	font-family: $base-font-family;
 	display: inline-block;
-	background-color: $medium-gray;
+	// background-color: $medium-gray;
 	font-weight: 600;
 	float: right;
 	@include media($smallest) {
@@ -765,19 +765,19 @@
 }
 
 .discovery {
-	background-color: $medium-gray;
+	background-color: $status-discovery;
 }
 
 .alpha {
-	background-color: $medium-blue;	
+	background-color: $status-alpha;
 }
 
 .beta {
-	background-color: $green;
+	background-color: $status-beta;
 }
 
 .live {
-	background-color: $red;
+	background-color: $status-live;
 }
 
 .dashboard-overview {
@@ -791,6 +791,7 @@
 .dashboard-overview,
 .dashboard-overview-numbers {
 	text-align: center;
+	color: black;
 	a {
 		text-decoration: none;
 		color: $dark-gray;
@@ -806,7 +807,7 @@
 		padding: 10px;
 		margin-right: 1.75% !important;
 		.status-description {
-			color: white;
+			color: black;
 			line-height: 1.1em;
 			font-size: 0.47em;
 		}

--- a/assets/_sass/base/_variables.scss
+++ b/assets/_sass/base/_variables.scss
@@ -24,12 +24,19 @@ $light-gray: #DDD;
 $light-red: #FBE3E4;
 $light-yellow: #FFF6BF;
 $light-green: #E6EFC2;
+
 // 18F Colors
 $blue: #1188ff;
 $medium-blue: #06d;
 $dark-blue: #03253e;
 $green: #5cb85c;
 $red: #c21;
+
+// project status colors
+$status-discovery: #f6eff7;
+$status-alpha: #bdc9e1;
+$status-beta: #67a9cf;
+$status-live: #02818a;
 
 // Background Color
 $base-background-color: white;

--- a/pages/colors/color.js
+++ b/pages/colors/color.js
@@ -1,0 +1,66 @@
+---
+permalink: /colors/color.js
+---
+
+var stages = [
+  {name: "discovery"},
+  {name: "alpha"},
+  {name: "beta"},
+  {name: "live"}
+];
+
+var schemes = [
+  "YlGn",
+  "YlGnBu",
+  "GnBu",
+  "BuGn",
+  "PuBuGn",
+  "PuBu",
+  "RdPu",
+  "PuRd",
+  "OrRd",
+  "YlOrRd",
+  "YlOrBr",
+  "Purples",
+  "Blues",
+  "Greens",
+  "Oranges",
+  "Reds"
+];
+
+var stage = d3.select("ul.dashboard-overview")
+  .selectAll("li")
+  .data(stages);
+
+var schemeSelect = d3.select("#scheme")
+  .on("change", function() {
+    location.hash = this.value;
+  });
+
+schemeSelect.selectAll("option")
+  .data(schemes)
+  .enter()
+  .append("option")
+    .attr("value", function(d) { return d; })
+    .text(function(d) { return d; });
+
+window.addEventListener("hashchange", onHashChange);
+if (location.hash) {
+  onHashChange();
+} else {
+  location.hash = "BuGn";
+}
+
+function setScheme(scheme) {
+  var colors = colorbrewer[scheme][stages.length];
+  stage
+    .select(".status")
+      .style("background-color", function(d, i) {
+        return d.color || colors[i];
+      });
+  schemeSelect.property("value", scheme);
+}
+
+function onHashChange(e) {
+  setScheme(location.hash.substr(1));
+}

--- a/pages/colors/index.html
+++ b/pages/colors/index.html
@@ -1,0 +1,43 @@
+---
+layout: bare
+title: "Status Colors"
+permalink: /colors/
+stages:
+  - status: discovery
+    description: "User needs are researched and identified."
+    projects: 3
+  - status: alpha
+    description: "A prototype is built to meet the main user needs."
+    projects: 5
+  - status: beta
+    description: "The service is improved, then tested in public."
+    projects: 3
+  - status: live
+    description: "The service is public and works well."
+    projects: 1
+---
+
+<section class="dashboard">
+  <script src="http://d3js.org/d3.v3.min.js"></script>
+  <script src="http://d3js.org/colorbrewer.v1.min.js"></script>
+  <style scoped>
+    @import url(style.css);
+  </style>
+
+  <h1>{{page.title}}</h1>
+  <p class="lead">Select a <a href="http://colorbrewer2.org">ColorBrewer</a> color scheme: <select id="scheme"></select></p>
+  <ul class="dashboard-overview">
+    {% for stage in page.stages %}
+    <li class="{{ stage.status }}">
+      <a href="?status={{ stage.status }}">
+        <span class="status {{ stage.status }}">{{ stage.status }}</span>
+        <p class="status-description">{{ stage.description }}</p>
+        <p class="project-count"><b>{{ stage.projects }}</b>
+        project{% if stage.projects > 1 || stage.projects < 1 %}s{% else %}{% endif %}</p>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+
+<script src="color.js"></script>

--- a/pages/colors/style.css
+++ b/pages/colors/style.css
@@ -1,0 +1,32 @@
+---
+permalink: /colors/style.css
+---
+
+.dashboard-overview .status,
+.dashboard-overview .status-description {
+  color: #000 !important;
+}
+
+.dashboard-overview .status {
+  background-color: transparent;
+  margin: -20px -20px 20px -20px;
+  display: block;
+}
+
+.dashboard-overview li {
+  height: auto;
+  border-top: 1em solid white;
+  background: #f9f9f9;
+  padding: 20px;
+}
+
+.dashboard-overview .project-count {
+  font-size: 50%;
+  color: #000 !important;
+  margin-bottom: 0;
+}
+
+select#scheme {
+  display: inline;
+  margin: 0 0 0 .5em;
+}


### PR DESCRIPTION
This is a really simple demo to test a new design for the "status" display using [ColorBrewer](http://colorbrewer2.org/) color schemes, per my comments on #152. You can view it locally at [/dashboard/colors/](http://localhost:4000/dashboard/colors/). Here is the original:

![image](https://cloud.githubusercontent.com/assets/113896/5171802/acd5ae5a-73cf-11e4-8721-919a03fdd1ea.png)

And here is the proposed change, using the `BuGn` color scheme:

![image](https://cloud.githubusercontent.com/assets/113896/5171827/ed14a58e-73cf-11e4-8071-dba0c2b8be4f.png)

I also like `PuRd`:

![image](https://cloud.githubusercontent.com/assets/113896/5172010/310975fc-73d1-11e4-915e-3c77170667bf.png)

Please try some of the other options listed in the drop-down and voice your preferences! The biggest issue that I can foresee would be the color contrast of black text on the darkest color ("live"). According to the [Sketch color contrast analyzer](https://github.com/getflourish/Sketch-Color-Contrast-Analyser) it's 4.9:1 for the `BuGn` scheme's `#238BC0` and 3.8:1 for `PuRd`'s `#CE1256`. The `GnBu` scheme's `#238BC0` outperforms both of those with 5.5:1 contrast, but that blue clashes with `#1188FF` pretty badly.

I've also templated the HTML so that it's easier to update. When we've picked a color scheme the hex values should just go straight into the YAML [page data](#diff-eaf5d3427fdd176b1f57f7138617ab5fR5) for each status "stage". This data could be made site-wide so that it could drive the CSS as well.
