### PR TITLE
adding s to http: x2

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -46,7 +46,7 @@
   team: chrisc, manger
   licenses:
     myra: Public Domain (CC0)
-  links: http://myra.treasury.gov
+  links: https://myra.treasury.gov
   status:
 
 - project: "PeaceCorps.gov"
@@ -331,7 +331,7 @@
   licenses:
     myusa: Public Domain (CC0)
   links:
-  - http://myusa.gov
+  - https://my.usa.gov
   status:
 
 - project: "MyUSCIS"


### PR DESCRIPTION
cc @konklone, @cscairns, @polastre 

Just noticed that two of the urls on 18f.gsa.gov/dashboard were `http` instead of `https`.

Given [our recent post](https://18f.gsa.gov/2014/11/13/why-we-use-https-in-every-gov-website-we-make/), it seems like it'd be a good idea to update those urls.  This updates the related links for MyRA and MyUSA accordingly.  
