### PR TITLE
Ruby interpreter and bundler paths for deployment

### DIFF
--- a/deploy/fabfile.py
+++ b/deploy/fabfile.py
@@ -38,11 +38,12 @@ now = time.strftime("%Y-%m-%d", time.localtime())
 
 if environment == 'staging':
   deploy_cmd = ("cd %s && git pull && bundle && "
-    "git submodule update --remote && ./_data/import-public.rb && "
+    "git submodule update --remote && "
+    "/opt/install/rbenv/shims/ruby ./_data/import-public.rb && "
     "git add _data/projects.yml && git commit -m 'Update data for %s' && "
-    "git push && ./go build >> %s" % (current, now, log))
+    "git push && ./go deploy_build >> %s" % (current, now, log))
 elif environment == 'production':
-  deploy_cmd = "cd %s && git pull && ./go build >> %s" % (current, log)
+  deploy_cmd = "cd %s && git pull && ./go deploy_build >> %s" % (current, log)
 else:
   exit(1)
 

--- a/go
+++ b/go
@@ -84,6 +84,12 @@ def ci_build
   puts 'Done!'
 end
 
+def deploy_build
+  puts 'Building the site...'
+  exec_cmd('/opt/install/rbenv/shims/bundle exec jekyll b --trace')
+  puts 'Site built successfully.'
+end
+
 COMMANDS = {
   :init => 'Set up the Hub dev environment',
   :update_gems => 'Execute Bundler to update gem set',
@@ -91,6 +97,7 @@ COMMANDS = {
   :serve => 'Serves the site at localhost:4000',
   :build => 'Builds the site',
   :ci_build => 'Builds the site for a CI system',
+  :deploy_build => 'Builds the site for staging or production',
 }
 
 def usage(exitstatus: 0)


### PR DESCRIPTION
The /home file system has the `noexec` bit set, so the ruby interpreter must
be called directly rather than relying on `#! /usr/bin/env ruby`.

The hookshot.js jobs appear to have a restricted PATH that does not include
/opt/install/rbenv/shims, so `bundle` and `ruby` require a full path.

@gboone 
