### PR TITLE
Embed civic issues tracker into project pages

### DIFF
--- a/_includes/civic-issues.html
+++ b/_includes/civic-issues.html
@@ -1,0 +1,4 @@
+<section class="dashboard-issue-tracker">
+    <p>Want to get involved? Check out our <a href="http://18fblog.tumblr.com/post/94543290971/the-contributors-guide-to-18f-code-for-the">Contributing Guide</a> and the Civic Issues tracker below.</p>
+    <iframe class="civic-issue-tracker" src="https://www.codeforamerica.org/geeks/civicissues/widget?organization_name=18F&labels=help%20wanted&number=12" width="100%" height="600" frameBorder="0"></iframe>
+</section>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -137,6 +137,7 @@ layout: bare
     </section>
   {% endif %}
 {% endfor %}
+{% include civic-issues.html %}
 
 {% include dashboard-contact.html %}
 

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -1020,6 +1020,15 @@
 	}
 }
 
+.dashboard-issue-tracker {
+	@include span-columns(9 of 9);
+
+	.civic-issue-tracker {
+		border-top: 1px solid $medium-gray;
+		border-bottom: 1px solid $medium-gray;
+	}
+}
+
 // 404
 //********************************************************
 .fours {


### PR DESCRIPTION
- Potentially closes #36
- Tracker embed is limited to 12 results and the 18f organization,
  happy to change those parameters
- Also linked to the contributing blog post.

Looks like this:
![screen shot 2015-03-27 at 1 08 50 pm](https://cloud.githubusercontent.com/assets/710999/6876206/7221e814-d482-11e4-9d7d-64ab5c0f7b1c.png)

Also, it's mobile friendly!
