### PR TITLE
Parse the root from the document's URL properly

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,8 +5,10 @@ var ORGANIZATION = "18f";
 // team api will always be at the same server the dashboard is running on, this
 // makes it flexible for local dev environments by sniffing out the beginning of
 // url and lopping any subdirectories off the browser's current document
-var urlRootIndex = document.URL.substr(7).indexOf('/');
-var urlRoot = document.URL.substr(0,urlRootIndex+7);
+var docUrl = document.URL;
+var substrBegin = docUrl.startsWith('https://') ? 8 : 7;
+var urlRootIndex = docUrl.substr(substrBegin).indexOf('/');
+var urlRoot = docUrl.substr(0,urlRootIndex+substrBegin);
 var TEAM = urlRoot+"/api/data/team.json"
 
 modules[0] = function(repo_name) {


### PR DESCRIPTION
Given the https:// scheme used by https://18f.gsa.gov/, the '7' used in the
original script was off-by-one, causing the error:

  Failed to load resource: net::ERR_NAME_NOT_RESOLVED

in the JavaScript console for the computed value:

  https://api/data/team.json

because the hostname was not corectly parsed. This change ensures the script
works for both http:// and https:// schemes. Tested by hardcoding a value for
`var url` with both http:// and https:// schemes for 18f.gsa.gov.

cc: @gboone @wslack @yozlet 
