### PR TITLE
Automates the project count

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,11 @@ layout: bare
 title: Dashboard
 permalink: /
 ---
-
+{% assign discovery = (site.data.projects | where:"stage","discovery")%}
+{% assign alpha = (site.data.projects | where:"stage","alpha")%}
+{% assign beta = (site.data.projects | where:"stage","beta")%}
+{% assign live = (site.data.projects | where:"stage","live")%}
+{% assign projects = [discovery, alpha, beta, live] %}
 <section class="dashboard">
   <h1>{{page.title}}</h1>
   <p class="lead">We are building digital services for the American people. Follow our progress and get involved here.</p>
@@ -11,7 +15,7 @@ permalink: /
     <a href="{{ site.baseurl }}/stages/#discovery">
       <li class="discovery"><span class="status">discovery</span>
         <p class="status-description">User needs are researched and identified.</p>
-        <p class="dashboard-overview-numbers">1</p>
+        <p class="dashboard-overview-numbers">{{ discovery.size }}</p>
       </li>
     </a>
     <a href="{{ site.baseurl }}/stages/#alpha">

--- a/index.html
+++ b/index.html
@@ -21,19 +21,19 @@ permalink: /
     <a href="{{ site.baseurl }}/stages/#alpha">
       <li class="alpha"><span class="status alpha">alpha</span>
         <p class="status-description">A prototype is built to meet the main user needs.</p>
-        <p class="dashboard-overview-numbers">5</p>
+        <p class="dashboard-overview-numbers">{{alpha.size}}</p>
       </li>
     </a>
     <a href="{{ site.baseurl }}/stages/#beta">
       <li class="beta"><span class="status beta">beta</span>
         <p class="status-description">The service is improved, then tested in public.</p>
-        <p class="dashboard-overview-numbers">10</p>
+        <p class="dashboard-overview-numbers">{{beta.size}}</p>
       </li>
     </a>
     <a href="{{ site.baseurl }}/stages/#live">
       <li class="live"><span class="status live">live</span>
         <p class="status-description">The service is public and works well.</p>
-        <p class="dashboard-overview-numbers">2</p>
+        <p class="dashboard-overview-numbers">{{live.size}}</p>
       </li>
     </a>
   </ul>


### PR DESCRIPTION
On the front page, automates the count of projects in each stage. Currently these are [hard coded into the template](https://github.com/18F/dashboard/blob/staging/index.html#L14-L32) and must be manually updated. Boo manual. Hooray automated.
