### PR TITLE
Fix team-api-update.js; rm extra function names

### DIFF
--- a/deploy/team-api-update.js
+++ b/deploy/team-api-update.js
@@ -67,10 +67,12 @@ webhook.on('refs/heads/' + config.teamApiBranch, function(info) {
     return;
   }
 
-  var updatePromise = null;
+  var repoDirs = config.repoDirs.slice(0);
+  var updatePromise = createUpdaterPromise(repoDirs.shift());
 
-  config.repoDirs.map(function (repoDir) {
-    updatePromise = createUpdaterPromise(repoDir);
+  repoDirs.map(function (repoDir) {
+    updatePromise = updatePromise.then(
+      function() { return createUpdaterPromise(repoDir) });
   });
 
   updatePromise.then(finish, finish);

--- a/deploy/team-api-update.js
+++ b/deploy/team-api-update.js
@@ -19,7 +19,7 @@ function TeamApiUpdater(repoDir) {
   this.repoDir = repoDir;
 }
 
-TeamApiUpdater.prototype.spawn = function spawn(actionDescription, path, args) {
+TeamApiUpdater.prototype.spawn = function (actionDescription, path, args) {
   var that = this;
   return new Promise(function(resolve, reject) {
     var spawnOpts = { cwd: that.repoDir, stdio: 'inherit' };
@@ -34,11 +34,11 @@ TeamApiUpdater.prototype.spawn = function spawn(actionDescription, path, args) {
   });
 };
 
-TeamApiUpdater.prototype.bundleInstall = function bundleInstall() {
+TeamApiUpdater.prototype.bundleInstall = function () {
   return this.spawn('bundle install', config.bundler, ['install']);
 };
 
-TeamApiUpdater.prototype.jekyllBuild = function jekyllBuild() {
+TeamApiUpdater.prototype.jekyllBuild = function () {
   return this.spawn('jekyll build', config.bundler,
     ['exec', 'jekyll', 'build', '--trace']);
 };
@@ -56,16 +56,21 @@ function finish(err) {
   }
 }
 
+function createUpdaterPromise(repoDir) {
+  var updater = new TeamApiUpdater(repoDir);
+  return updater.bundleInstall()
+    .then(function() { return updater.jekyllBuild(); });
+}
+
 webhook.on('refs/heads/' + config.teamApiBranch, function(info) {
   if (!isValidUpdate(info)) {
     return;
   }
 
-  var updatePromise = new Promise(function(resolve) { resolve(); });
+  var updatePromise = null;
+
   config.repoDirs.map(function (repoDir) {
-    var updater = new TeamApiUpdater(config.repoDir);
-    updatePromise.then(function() { return updater.bundleInstall(); })
-      .then(function() { return updater.jekyllBuild(); });
+    updatePromise = createUpdaterPromise(repoDir);
   });
 
   updatePromise.then(finish, finish);


### PR DESCRIPTION
The original promise function was returning/resolving early, causing the `finish` callback to fire before the actual bundle/jekyll calls. This also gets rid of the redundant function names as @arowla and @shawnbot pointed out in #247.

Also, @gboone, I noticed that the templates don't quite match up with the `.about.yml` data quite yet; will send a PR to munge data in the short-term, until the format stabilizes.

cc: @jeremiak @dhcole @jmcarp @monfresh @gbinal @melodykramer @leahbannon

(So close!)
