### PR TITLE
Fix .about.yml, munge data to match template

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -94,4 +94,4 @@ links:
 
 # Email addresses of points-of-contact
 contact:
-- mailto: gregory.boone@gsa.gov
+- gregory.boone@gsa.gov

--- a/_plugins/dashboard.rb
+++ b/_plugins/dashboard.rb
@@ -27,6 +27,15 @@ module Dashboard
       FIELDS_TO_TRANSLATE.each do |from, to|
         project_data[to] = project_data[from] unless project_data[to]
       end
+
+      contact = project_data['contact']
+      project_data['contact'] = contact.join ',' if contact.instance_of? Array
+
+      licenses = project_data['licenses']
+      return if licenses.nil?
+      project_data['licenses'] = licenses.map do |key, value|
+        [key, (value.instance_of?(Hash) ? value['name'] : value)]
+      end.to_h
     end
 
     def self.create(site, project_id, project_data)


### PR DESCRIPTION
Once we've switched all projects/repos to .about.yml, this code can go away.

Also happy to entertain other ideas about a migration path, @gboone.
