### PR TITLE
Fixes the project lists

### DIFF
--- a/_includes/projectlist.html
+++ b/_includes/projectlist.html
@@ -2,8 +2,8 @@
   <h3>Projects currently in this phase:</h2>
   <ul>
   {% for project in site.data.projects %}
-    {% if project[1].stage == include.stage %}
-    <li><a href="{{site.baseurl}}/project/{{project[0]}}">{{ project[1].project }}</a></li>
+    {% if project[1]['stage'] == include.stage %}
+    <li><a href="{{site.baseurl}}/project/{{project[0]}}">{{ project[1]['full_name'] }}</a></li>
     {% endif %}
   {% endfor %}
 </ul>


### PR DESCRIPTION
Breaking changes from integrating Team API caused the list of projects
in each category to break.
