### PR TITLE
Adding .about.yml errors to the project page, if the team-api includes them.

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -131,6 +131,16 @@ layout: bare
     </div>
   {% endif %}
 
+  <!-- errors -->
+  {% if project.errors %}
+    <div>
+      <h1><i class="fa fa-chevron-right"></i> .about.yml errors</h1>
+      <ul>{% for item in project.errors %}
+        <li>{{ item }}</li>{% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
   </div>
 </section>
 


### PR DESCRIPTION
Iterates over the errors (if any) and includes them on the project page. Errors must be exposed by the team-api for them to show up here.
