### PR TITLE
Remove production dashboard from automatic team-api updater

### DIFF
--- a/deploy/team-api-importer-config.json
+++ b/deploy/team-api-importer-config.json
@@ -4,7 +4,6 @@
   "teamApiRepo":   "18F/team-api.18f.gov",
   "teamApiBranch": "master",
   "repoDirs": [
-    "/home/site/staging/dashboard",
-    "/home/site/production/dashboard"
+    "/home/site/staging/dashboard"
   ]
 }


### PR DESCRIPTION
Per 18F/dashboard#281 we want to be able to proof content on staging before it hits production. This removes the production webhook.
