### PR TITLE
Un-ignores the jekyll config, updates go script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 /_site
+.sass-cache
 .DS_Store
 *.log
-/.sass-cache/
-_config.yml
 *.pyc
 _data/projects.json
 node_modules/

--- a/go
+++ b/go
@@ -26,23 +26,6 @@
 #
 # Author: Mike Bland (michael.bland@gsa.gov)
 # Date:   2015-01-10
-
-MIN_VERSION = "2.1.5"
-
-unless RUBY_VERSION >= MIN_VERSION
-  puts <<EOF
-
-*** ABORTING: Unsupported Ruby version ***
-
-Ruby version #{MIN_VERSION} or greater is required to work with the Hub, but
-this Ruby is version #{RUBY_VERSION}. Consider using a version manager such as
-rbenv (https://github.com/sstephenson/rbenv) or rvm (https://rvm.io/)
-to install a Ruby version specifically for Hub development.
-
-EOF
-  exit 1
-end
-
 def exec_cmd(cmd)
   exit $?.exitstatus unless system(cmd)
 end
@@ -86,11 +69,15 @@ def ci_build
 end
 
 def deploy
+  puts 'Updating data from Team-API'
+  update_data
   puts 'Pulling the latest changes...'
   exec_cmd('git pull')
   puts 'Building the site...'
   exec_cmd('/opt/install/rbenv/shims/bundle exec jekyll b --trace')
   puts 'Site built successfully.'
+  require 'time'
+  puts Time.now()
 end
 
 def test_build


### PR DESCRIPTION
The go script will now update the data from the Team-API every time it
deploys. Even though the staging server will udpate data on team API
updates, production does not. Plus, really, unless we're doing millions
of deploys every day, it probably doesn't hurt to pull the data fresh
with a site rebuild on staging
