### PR TITLE
Updates the go script to pull fresh from team-api on serve

### DIFF
--- a/go
+++ b/go
@@ -41,11 +41,7 @@ def init
   exec_cmd 'bundle_install'
 end
 
-<<<<<<< HEAD
 def install_gems
-=======
-def update_gems
->>>>>>> origin/staging
   exec_cmd 'bundle install'
   exec_cmd 'git add Gemfile.lock'
 end

--- a/go
+++ b/go
@@ -59,7 +59,7 @@ def init
 end
 
 def update_gems
-  exec_cmd 'bundle update'
+  exec_cmd 'bundle install'
   exec_cmd 'git add Gemfile.lock'
 end
 
@@ -68,10 +68,13 @@ def update_data
 end
 
 def serve
+  puts 'Updating from the team API'
+  update_data
   exec 'bundle exec jekyll serve --trace'
 end
 
 def build
+  update_data
   puts 'Building the site...'
   exec_cmd('bundle exec jekyll b --trace')
   puts 'Site built successfully.'

--- a/go
+++ b/go
@@ -58,7 +58,7 @@ def init
   exec_cmd 'bundle_install'
 end
 
-def update_gems
+def install_gems
   exec_cmd 'bundle install'
   exec_cmd 'git add Gemfile.lock'
 end
@@ -103,7 +103,7 @@ end
 
 COMMANDS = {
   :init => 'Set up the Hub dev environment',
-  :update_gems => 'Execute Bundler to update gem set',
+  :install_gems => 'Execute Bundler to update gem set',
   :update_data => 'Updates data files from data-private',
   :serve => 'Serves the site at localhost:4000',
   :build => 'Builds the site',


### PR DESCRIPTION
Pulls fresh data every time `jekyll serve` is invoked. This will not,
importantly, pull on every automatic rebuild. Only when `./go serve` is
run will new data get pulled in.
