### PR TITLE
Better support for not using the Team API

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,8 +23,7 @@ exclude:
 - tests
 - vendor
 
-# To disable fetching from the Team API and to build from local data, prefix
-# the following field with an underscore.
+# To disable fetching from the Team API and to build from local data, remove this section
 team_api:
   #baseurl: http://localhost:4001/public/api/
   #suffix: api.json

--- a/_config.yml.sample
+++ b/_config.yml.sample
@@ -6,7 +6,24 @@ description: "18F builds effective, user-centric digital services focused on the
 sass:
   sass_dir: assets/_sass
 
-gems: [bourbon]
-
+destination: _site/dashboard
 baseurl: /dashboard
 #baseurl: localhost:4000
+exclude:
+- CONTRIBUTING.md
+- Gemfile
+- Gemfile.lock
+- LICENSE.md
+- README.md
+- deploy
+- go
+- gulpfile.js
+- node_modules
+- package.json
+- tests
+- vendor
+
+# If you would like to pull projects from an api, make sure your API is well structured to match the dashboard and has a `projects` endpoint. Then, use `baseurl` and `host` below with the relevan information about your API and run `./go update_data` This will overwrite your local `projects.json` file.
+team_api:
+  #baseurl: http://localhost:4001/public/api/
+  #suffix: api.json

--- a/_data/import-public.rb
+++ b/_data/import-public.rb
@@ -7,13 +7,17 @@
 
 require 'json'
 require 'open-uri'
+require 'safe_yaml'
 
-DATA_DIR = File.dirname __FILE__
-PROJECT_DATA_URL = 'https://team-api.18f.gov/public/api/projects/'
+if File.exists?('../_config.yml')
+  config = YAML.safe_load_file('../_config.yml')
+  DATA_DIR = File.dirname __FILE__
+  PROJECT_DATA_URL = "#{config['team_api']['baseurl']}projects/"
 
-open(PROJECT_DATA_URL) do |projects|
-  open(File.join(DATA_DIR, 'projects.json'), 'w') do |f|
-    f.write JSON.pretty_generate(
-      JSON.parse(projects.read)['results'].map { |p| [p['name'], p] }.to_h)
+  open(PROJECT_DATA_URL) do |projects|
+    open(File.join(DATA_DIR, 'projects.json'), 'w') do |f|
+      f.write JSON.pretty_generate(
+        JSON.parse(projects.read)['results'].map { |p| [p['name'], p] }.to_h)
+    end
   end
 end

--- a/go
+++ b/go
@@ -47,7 +47,7 @@ def update_gems
 end
 
 def update_data
-  exec_cmd 'cd _data && ./import-public.rb'
+  exec_cmd 'bundle exec ruby _data/import-public.rb'
 end
 
 def serve


### PR DESCRIPTION
This adjusts the import-public script to only work if there's an API baseurl specified in the _config.yml file. This will help people looking to reuse this Dashboard for their own agency by not automatically pulling information about our projects out of our API. The way it was written, every time `serve` or `build` were issued from the go script, new data would be pulled down and a new projects.json file created. This would make it very tricky to adapt as a potential user might write their own `projects.json` file only to have it overwritten as soon as the site is built.

Along these same lines, we may want to think about a script that will setup this repo better for someone outside of 18F looking to reuse this code. Right now a reuser would have to do the following:
1. Set up the project
2. Remove the _config.yml that's in the repo and rename the _config.yml.sample to _config.yml
3. Rename the projects.json.example file to "projects.json". 

Now, if you run `./go serve` now you should see something similar to what you see at 18f.gsa.gov/dashboard
1. Change the values in the _config.yml file to better reflect your organization.
2. Rename the projects in the projects.json file you created before and replace their values with ones that fit your organizations projects.
