### PR TITLE
Updates to project list to account for missing projects

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -45,12 +45,12 @@ team:
   role: lead
 
 # Partners for whom the project is developed
-#partners:
-#- 
+partners:
+- 18F
 
 # Brief descriptions of significant project developments
 #milestones:
-#- 
+#-
 
 # Technologies used to build the project
 stack:
@@ -68,7 +68,7 @@ stack:
 #   url: URL for detailed information
 #   badge: URL for the status badge
 #services:
-#- 
+#-
 
 # Licenses that apply to the project and/or its components (required)
 # Items by property name pattern:
@@ -82,7 +82,7 @@ licenses:
 
 # Blogs or websites associated with project development
 #blog:
-#- 
+#-
 
 # Links to project artifacts
 # Items:
@@ -96,4 +96,3 @@ links:
 contact:
 - url: mailto:gregory.boone@gsa.gov
   text: Greg Boone
-

--- a/_data/partners.yml
+++ b/_data/partners.yml
@@ -1,3 +1,6 @@
+18f:
+  url: https://18f.gsa.gov
+  full_name: 18F
 u-s-department-of-treasury:
   url: http://treasury.gov
   full_name: U.S. Department of Treasury

--- a/_data/project_filter.yml
+++ b/_data/project_filter.yml
@@ -12,7 +12,6 @@
 - dataact
 - discovery
 - ekip-api
-- doi-extractives-data
 - fbopen
 - federalist
 - foia

--- a/_data/project_filter.yml
+++ b/_data/project_filter.yml
@@ -23,3 +23,4 @@
 - pulse
 - sbirez
 - uscis
+- useiti-report

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -54,9 +54,9 @@ layout: bare
     {% endif %}
 
     <!-- partners -->
-    {% if project.partner %}
+    {% if project.partners %}
       <div>
-        {% if project.partner.size > 1 %}
+        {% if project.partners.size > 1 %}
           <h1><i class="fa fa-chevron-right"></i> partners</h1>
         {% else %}
           <h1><i class="fa fa-chevron-right"></i> partner</h1>


### PR DESCRIPTION
Adds a new name for the USEITI project and 18F as a partner agency to fix some errors in the Dashboard.
