### PR TITLE
Redirect to

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gem 'jekyll-sitemap'
 gem 'jekyll', '3.0.1'
 gem 'hash-joiner'
 gem 'safe_yaml'
+group :jekyll_plugins do
+    gem 'jekyll-redirect-from', '~> 0.9'
+end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,8 @@ GEM
       mercenary (~> 0.3.3)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
+    jekyll-redirect-from (0.9.0)
+      jekyll (>= 2.0)
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)
     jekyll-sitemap (0.9.0)
@@ -38,6 +40,7 @@ PLATFORMS
 DEPENDENCIES
   hash-joiner
   jekyll (= 3.0.1)
+  jekyll-redirect-from (~> 0.9)
   jekyll-sitemap
   safe_yaml
 

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,8 @@ exclude:
 - tests
 - vendor
 
+gems:
+  - jekyll-redirect-from
 # To disable fetching from the Team API and to build from local data, remove this section
 team_api:
   #baseurl: http://localhost:4001/public/api/

--- a/_plugins/dashboard.rb
+++ b/_plugins/dashboard.rb
@@ -43,6 +43,13 @@ module Dashboard
       FIELDS_TO_TRANSLATE.each do |from, to|
         project_data[to] = project_data[from] unless project_data[to]
       end
+      original_name = project_data['name']
+      if original_name.scan(/[A-Z]/).size > 0
+        project_data['redirect_from'] = Array.new
+        project_data['redirect_from'].push("project/#{original_name}")
+      end
+      project_data['name'] = original_name.downcase
+
       munge_licenses project_data
       munge_github project_data
     end
@@ -50,6 +57,7 @@ module Dashboard
     def self.create(site, project_id, project_data)
       page = new site, project_id
       munge_project_data project_data
+
       page.data['project'] = project_data
       page.data['title'] = project_data['full_name']
       site.pages << page

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ permalink: /
         {% if project.status != "Hold" %}
         <div class="dashboard-projects-content">
           <div>
-            <a href="{{ site.baseurl }}/project/{{ project_name }}"><h1>{{project.full_name}} <i class="fa fa-chevron-right"></i><i class="fa fa-chevron-right"></i><span class="status {{ project.stage }}">{% if project.stage %}{{ project.stage }}{% else %}unknown{% endif %}</span></h1></a>
+            <a href="{{ site.baseurl }}/project/{{ project_name | slugify }}"><h1>{{project.full_name}} <i class="fa fa-chevron-right"></i><i class="fa fa-chevron-right"></i><span class="status {{ project.stage }}">{% if project.stage %}{{ project.stage }}{% else %}unknown{% endif %}</span></h1></a>
           </div>
           <div>
             <p>{% if project.description %}{{ project.description }}{% else %}Project description coming soon.{% endif %}</p>

--- a/pages/project/doi-extractives-data.md
+++ b/pages/project/doi-extractives-data.md
@@ -1,0 +1,5 @@
+---
+permalink: project/doi-extractives-data/
+redirect_to:
+- /dashboard/project/useiti-report/
+---

--- a/pages/project/openfec.md
+++ b/pages/project/openfec.md
@@ -1,0 +1,5 @@
+---
+permalink: project/openfec/
+redirect_to:
+- /dashboard/project/betafec/
+---

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -3,8 +3,8 @@ require 'safe_yaml'
 
 data = SafeYAML.load_file '_data/project_filter.yml', safe: true
 redirects = Dir.glob('pages/project/*')
-expect_size = data.size + redirects
-actual_size = Dir.glob('_site/dashboard/project/*')
+expect_size = data.size + redirects.size
+actual_size = Dir.glob('_site/dashboard/project/*').size
 if expect_size == actual_size
   puts "Dashboard pages generated correctly. There are #{actual_size} projects."
   exit 0

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -2,10 +2,9 @@
 require 'safe_yaml'
 
 data = SafeYAML.load_file '_data/project_filter.yml', safe: true
-redirects = Dir.open('pages/project').count-2
+redirects = Dir.glob('pages/project/*')
 expect_size = data.size + redirects
-projectdir = Dir.open('_site/dashboard/project')
-actual_size = projectdir.count-2
+actual_size = Dir.glob('_site/dashboard/project/*')
 if expect_size == actual_size
   puts "Dashboard pages generated correctly. There are #{actual_size} projects."
   exit 0

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -2,8 +2,9 @@
 require 'safe_yaml'
 
 data = SafeYAML.load_file '_data/project_filter.yml', safe: true
-expect_size = data.size
-projectdir = Dir.new('_site/dashboard/project')
+redirects = Dir.open('pages/project').count-2
+expect_size = data.size + redirects
+projectdir = Dir.open('_site/dashboard/project')
 actual_size = projectdir.count-2
 if expect_size == actual_size
   puts "Dashboard pages generated correctly. There are #{actual_size} projects."


### PR DESCRIPTION
This pull request adds the [jekyll-redirect-from plugin](https://github.com/jekyll/jekyll-redirect-from) and configures the Dashboard plugin to redirect certain URLs automatically.

The Dashboard plugin now lowercases all 'name' values for projects and automatically adds the redirect for the original uppercased string.

For example, the project betaFEC has the name `betaFEC`. Before this change that would result in a url `dashboard/project/betaFEC/`. After this change it will result in a url `dashboard/project/betafec` that also
responds to the named url.

Lowercase urls are a specific rule in the 18F content guide. This commit (714977d) also ensures that URLs listed on the index page are written lower case.

80c6bcf also adds two redirection pages for the USEITI and FEC projects which changed names in the Team API. (See also 18F/team-api#146)
