### PR TITLE
Adding support for process links.

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -135,9 +135,13 @@ layout: bare
   {% if project.links %}
 
     {% assign has_api = false %}
+    {% assign has_process = false %}
     {% for item in project.links %}
       {% if item.category == 'api' %}
         {% assign has_api = true %}
+      {% endif %}
+      {% if item.category == 'process' %}
+        {% assign has_process = true %}
       {% endif %}
     {% endfor %}
 
@@ -147,6 +151,17 @@ layout: bare
       <h1><i class="fa fa-chevron-right"></i> api links</h1>
       <ul>{% for item in project.links %}
       {% if item.category == 'api' %}
+        <li><a href="{{ item.url }}">{{ item.text }}</a></li>{% endif %}{% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+  <!-- process links -->
+    {% if has_process == true %}
+    <div>
+      <h1><i class="fa fa-chevron-right"></i> process links</h1>
+      <ul>{% for item in project.links %}
+      {% if item.category == 'process' %}
         <li><a href="{{ item.url }}">{{ item.text }}</a></li>{% endif %}{% endfor %}
       </ul>
     </div>


### PR DESCRIPTION
This is extremely similar to #289, which added api links. Process links are links that point to a board (waffle, trello, etc.) or document that describes the development process for the project.

<img width="516" alt="screenshot 2015-11-30 14 58 36" src="https://cloud.githubusercontent.com/assets/933586/11482803/e2a2116e-9772-11e5-8dd7-9166c9cb708e.png">
