### PR TITLE
Comment errors

### DIFF
--- a/_data/project_filter.yml
+++ b/_data/project_filter.yml
@@ -15,7 +15,7 @@
 - fbopen
 - federalist
 - foia
-- midas
+- openopps
 - myra
 - myusa
 - peacecorps-site

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -180,7 +180,7 @@ layout: bare
   <!-- end of project links section -->
   {% endif %}
 
-  <!-- errors -->
+  <!-- errors
   {% if project.errors %}
     <div>
       <h1><i class="fa fa-chevron-right"></i> .about.yml errors</h1>
@@ -189,6 +189,7 @@ layout: bare
       </ul>
     </div>
   {% endif %}
+   -->
 
   </div>
 </section>


### PR DESCRIPTION
Instead of having errors visible on the page, I propose rendering them as a comment:

![image](https://cloud.githubusercontent.com/assets/41906/11821836/56d9a58e-a320-11e5-8600-a259a428cc91.png)

then we can see them for debugging, but we can also choose to ignore them
