### PR TITLE
Adding support for subprojects and repo links.

### DIFF
--- a/_includes/project-code.html
+++ b/_includes/project-code.html
@@ -1,0 +1,28 @@
+{% if current_url.name && current_url.description %}
+  {% assign full_repo_name = current_url.name %}
+  {% assign repo_name = current_url.name | split: "/" | last %}
+  {% assign repo_desc = current_url.description %}
+{% else %}
+  {% assign full_repo_name = current_url %}
+  {% assign repo_name = current_url | split: "/" | last %}
+{% endif %}
+<div class="{{ repo_name | replace: ".", "-" }} repo">
+  <h1><i class="fa fa-github-alt"></i> <a class="github-url" href="https://github.com/{{ full_repo_name }}">{{ full_repo_name }}</a></h1>
+{% if repo_desc %}
+  <p>{{ repo_desc }}</p>
+{% endif %}
+  <ul>
+    <li class="issues"><i class="fa fa-exclamation-circle"></i> Issues: </li>
+    <li class="stars"><i class="fa fa-star"></i> Stars: </li>
+    <li class="forks"><i class="fa fa-code-fork"></i> Forks: </li>
+    {% if current_license[repo_name] %}
+      {% if current_license[repo_name].name %}
+        {% assign license_name = current_license[repo_name].name %}
+      {% else %}
+        {% assign license_name = current_license[repo_name] %}
+      {% endif %}
+      {% capture branch %}{% if current_branch %}{{ current_branch | map: repo_name }}{% else %}master{%endif%}{% endcapture %}
+        <li><i class="fa fa-legal {{ repo_name }}"></i> License: <a href="https://github.com/{{ full_repo_name }}/blob/{{ branch }}/LICENSE.md">{{ license_name }}</a></li>
+    {% endif %}
+  </ul>
+</div>

--- a/_includes/project-links.html
+++ b/_includes/project-links.html
@@ -1,0 +1,42 @@
+{% assign has_api = false %}
+{% assign has_process = false %}
+{% for item in current_links %}
+  {% if item.category == 'api' %}
+    {% assign has_api = true %}
+  {% endif %}
+  {% if item.category == 'process' %}
+    {% assign has_process = true %}
+  {% endif %}
+{% endfor %}
+
+<!-- api links -->
+{% if has_api == true %}
+<div>
+  <h1><i class="fa fa-chevron-right"></i> api links</h1>
+  <ul>{% for item in current_links %}
+  {% if item.category == 'api' %}
+    <li><a href="{{ item.url }}">{{ item.text }}</a></li>{% endif %}{% endfor %}
+  </ul>
+</div>
+{% endif %}
+
+<!-- process links -->
+{% if has_process == true %}
+<div>
+  <h1><i class="fa fa-chevron-right"></i> process links</h1>
+  <ul>{% for item in current_links %}
+  {% if item.category == 'process' %}
+    <li><a href="{{ item.url }}">{{ item.text }}</a></li>{% endif %}{% endfor %}
+  </ul>
+</div>
+{% endif %}
+
+<!-- additional links -->
+<div>
+  <h1><i class="fa fa-chevron-right"></i> related links</h1>
+  <ul>{% for item in current_links %}
+    {% if item.category != 'api' and item.category != 'process' and item.category != 'repo' %}
+    <li>{% if item.url %}<a href="{{ item.url }}">{{ item.text }}</a></li>{% else %}<a href="{{ item }}">{{ item }}</a>{% endif %}</li>
+    {% endif %}{% endfor %}
+  </ul>
+</div>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -67,6 +67,11 @@ layout: bare
       </div>
     {% endif %}
 
+    {% if project.children %}
+      <h1><i class="fa fa-chevron-right"></i> projects</h1>
+      <h2>{{ project.full_name }}</h2>
+    {% endif %}
+      
     <!-- milestones -->
     {% if project.milestones %}
       <div>
@@ -83,37 +88,11 @@ layout: bare
     {% if project.github %}
     <div class="dashboard-code">
       <h1><i class="fa fa-chevron-right"></i> code</h1>
+      {% assign current_license = project.licenses %}
+      {% assign current_branch = project.licenseBranch %}
       {% for url in project.github %}
-        {% if url.name && url.description %}
-          {% assign full_repo_name = url.name %}
-          {% assign repo_name = url.name | split: "/" | last %}
-          {% assign repo_desc = url.description %}
-        {% else %}
-          {% assign full_repo_name = url %}
-          {% assign repo_name = url | split: "/" | last %}
-        {% endif %}
-      <div class="{{ repo_name | replace: ".", "-" }} repo">
-        <h1>
-          {% if project.github | first %}
-          <i class="fa fa-github-alt"></i> <a class="github-url" href="https://github.com/{{ full_repo_name }}">{{ full_repo_name }}</a>
-          {% else %}
-          <i class="fa fa-github-alt"></i> <a href="https://github.com/{{ full_repo_name }}">{{ full_repo_name }}</a>
-          {% endif %}
-        </h1>
-        {% if repo_desc %}
-          <p>{{ repo_desc }}</p>
-        {% endif %}
-        <ul>
-          <li class="issues"><i class="fa fa-exclamation-circle"></i> Issues: </li>
-          <li class="stars"><i class="fa fa-star"></i> Stars: </li>
-          <li class="forks"><i class="fa fa-code-fork"></i> Forks: </li>
-          {% for license in project.licenses %}{% if license[0] == repo_name %}
-          {% capture branch %}{% if project.licenseBranch %}{{ project.licenseBranch | map: repo_name }}{% else %}master{%endif%}{% endcapture %}
-          <li><i class="fa fa-legal {{ license[0] }}"></i> License: <a href="https://github.com/{{ full_repo_name }}/blob/{{ branch }}/LICENSE.md">{{ license[1] }}</a></li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+        {% assign current_url = url %}
+        {% include project-code.html %}
       {% endfor %}
     </div>
     {% endif %}
@@ -133,52 +112,45 @@ layout: bare
 -->
 
   {% if project.links %}
-
-    {% assign has_api = false %}
-    {% assign has_process = false %}
-    {% for item in project.links %}
-      {% if item.category == 'api' %}
-        {% assign has_api = true %}
-      {% endif %}
-      {% if item.category == 'process' %}
-        {% assign has_process = true %}
-      {% endif %}
-    {% endfor %}
-
-  <!-- api links -->
-    {% if has_api == true %}
-    <div>
-      <h1><i class="fa fa-chevron-right"></i> api links</h1>
-      <ul>{% for item in project.links %}
-      {% if item.category == 'api' %}
-        <li><a href="{{ item.url }}">{{ item.text }}</a></li>{% endif %}{% endfor %}
-      </ul>
-    </div>
-    {% endif %}
-
-  <!-- process links -->
-    {% if has_process == true %}
-    <div>
-      <h1><i class="fa fa-chevron-right"></i> process links</h1>
-      <ul>{% for item in project.links %}
-      {% if item.category == 'process' %}
-        <li><a href="{{ item.url }}">{{ item.text }}</a></li>{% endif %}{% endfor %}
-      </ul>
-    </div>
-    {% endif %}
-
-  <!-- additional links -->
-    <div>
-      <h1><i class="fa fa-chevron-right"></i> related links</h1>
-      <ul>{% for item in project.links %}
-        {% if item.category != 'api' and item.category != 'process' %}
-        <li>{% if item.url %}<a href="{{ item.url }}">{{ item.text }}</a></li>{% else %}<a href="{{ item }}">{{ item }}</a>{% endif %}</li>
-        {% endif %}{% endfor %}
-      </ul>
-    </div>
-
-  <!-- end of project links section -->
+    {% assign current_links = project.links %}
+    {% include project-links.html %}
   {% endif %}
+
+  {% for child in project.children %}
+  <div>
+    <h2>{{ child.full_name }}</h2>
+    <p>{{ child.description }}</p>
+  </div>
+    <!-- milestones -->
+    {% if child.milestones %}
+      <div>
+        <h1><i class="fa fa-chevron-right"></i> milestones</h1>
+        <ul>
+          {% for item in child.milestones %}
+          <li>{{ item }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+
+    <!-- code -->
+    {% if child.github %}
+    <div class="dashboard-code">
+      <h1><i class="fa fa-chevron-right"></i> code</h1>
+      {% assign current_license = child.licenses %}
+      {% assign current_branch = child.licenseBranch %}
+      {% for url in child.github %}
+        {% assign current_url = url %}
+        {% include project-code.html %}
+      {% endfor %}
+    </div>
+    {% endif %}
+
+    {% if child.links %}
+      {% assign current_links = child.links %}
+      {% include project-links.html %}
+    {% endif %}
+  {% endfor %}
 
   <!-- errors -->
   {% if project.errors %}

--- a/_plugins/dashboard.rb
+++ b/_plugins/dashboard.rb
@@ -54,7 +54,7 @@ module Dashboard
 
     def self.append_repo_links(project_data, projects)
       links = project_data['links']
-      if links
+      if links && project_data['github']
         repo_links = links.map do |link|
           get_repo_name_from_url(link, projects) if link['category'] == 'repo'
         end.compact

--- a/_plugins/dashboard.rb
+++ b/_plugins/dashboard.rb
@@ -6,6 +6,7 @@ module Dashboard
   # Generates an individual project page from project data.
   class ProjectPage < Jekyll::Page
     private_class_method :new
+    attr_reader :site
 
     def initialize(site, project_id)
       @site = site
@@ -32,31 +33,61 @@ module Dashboard
       end
     end
 
-    def self.munge_github(project_data)
+    def self.get_github_description(project_name, projects)
+      if projects[project_name] && projects[project_name]['github']
+        projects[project_name]['github'][0]['description']
+      end
+    end
+
+    def self.get_repo_name_from_url(url, projects)
+      project_name = full_name = url['url']
+      parts = project_name.split '/'
+      if parts.length > 1
+        project_name = parts[-1]
+        full_name = parts[-2, 2].join '/'
+      end
+      desc = get_github_description project_name, projects
+      { 'name' => full_name,
+        'description' => (url['text'] || desc || '')
+      }
+    end
+
+    def self.append_repo_links(project_data, projects)
+      links = project_data['links']
+      if links
+        repo_links = links.map do |link|
+          get_repo_name_from_url(link, projects) if link['category'] == 'repo'
+        end.compact
+        project_data['github'] += repo_links
+      end
+    end
+
+    def self.munge_github(project_data, projects)
       github = project_data['github']
       unless github.is_a?(Array) || github.nil?
         project_data['github'] = [github]
       end
+      append_repo_links(project_data, projects)
     end
 
-    def self.munge_project_data(project_data)
+    def self.munge_project_data(project_data, projects)
       FIELDS_TO_TRANSLATE.each do |from, to|
         project_data[to] = project_data[from] unless project_data[to]
       end
       original_name = project_data['name']
       if original_name.scan(/[A-Z]/).size > 0
-        project_data['redirect_from'] = Array.new
+        project_data['redirect_from'] = []
         project_data['redirect_from'].push("project/#{original_name}")
       end
       project_data['name'] = original_name.downcase
 
       munge_licenses project_data
-      munge_github project_data
+      munge_github project_data, projects
     end
 
     def self.create(site, project_id, project_data)
       page = new site, project_id
-      munge_project_data project_data
+      munge_project_data project_data, site.data['projects']
 
       page.data['project'] = project_data
       page.data['title'] = project_data['full_name']
@@ -73,6 +104,7 @@ module Dashboard
     # for the Hub.
     def generate(site)
       import_team_api_data site
+      assign_children_to_parents site.data['projects']
       filter_projects site
       generate_project_pages site
     end
@@ -85,6 +117,24 @@ module Dashboard
       open(endpoint, 'Host' => team_api['host']) do |endpoint_data|
         projects = JSON.parse(endpoint_data.read)['results']
         site.data['projects'] = projects.map { |p| [p['name'], p] }.to_h
+      end
+    end
+
+    # we want to exclude a project if parent = child or if ref'ed as a link
+    def exclude_project?(project, parent, projects)
+      return true if parent.nil? || parent == project || !projects[parent]
+      repos = projects[parent]['links'].select do |r|
+        r['category'] == 'repo' && r['url'].include?(project)
+      end
+      return true unless repos.empty?
+    end
+
+    def assign_children_to_parents(projects)
+      projects.each do |id, p|
+        parent = p['parent']
+        next if exclude_project?(id, parent, projects)
+        children = (projects[parent]['children'] || []) << p
+        projects[parent]['children'] = children
       end
     end
 

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -990,6 +990,10 @@
 			font-size: 1em;
 		}
 	}
+	h2 {
+		font-size: 1.3em;
+		font-style: italic; 
+	}
 	p {
 		margin-bottom: 0;
 		padding-top: 7px;

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -19,7 +19,9 @@ var aboutYmlValidator = require('about-yml-validator');
 var validator = new aboutYmlValidator();
 
 var includes = {
-  'list-partners.html': fs.readFileSync(__dirname + '/../../_includes/list-partners-preview.html', 'utf8')
+  'list-partners.html': fs.readFileSync(__dirname + '/../../_includes/list-partners-preview.html', 'utf8'),
+  'project-code.html': fs.readFileSync(__dirname + '/../../_includes/project-code.html', 'utf8'),
+  'project-links.html': fs.readFileSync(__dirname + '/../../_includes/project-links.html', 'utf8')
 };
 
 var url = cleanGithubUrl(window.location.search);


### PR DESCRIPTION
Subprojects:
Subprojects are designated with a `parent` tag in the about.yml. The dashboard plugin will pull them into the parent repo in a children key.

Repo Links:
Repo Links are designated by setting the link `category` to `repo`. The link text should be either a full url to a github repo (https://github.com/18F/federalist) or a org/name slug (18F/federalist). Repo links will not show up in the related links, but will be listed in the `code` section of the site. A repo link has precedence over a subproject; a subproject will not be listed as such if it is also included as a repo link.

Layout/Include Changes:
- The `code` and `links` sections were pulled into seperate includes.
- A new style was added to for `h2` project name headers.
- The code to display a repo's license information was simplified.
- The look does not change for projects without child projects.

Concerns:
- The repo links functionality and subprojects won't 'just work' with the ongoing `preview` functionality that is being developed, since both of those pieces are done in the dashboard plugin.
- Not thrilled with the layout for multiprojects, I'd love to get some suggestions.

Multi-project layout, sporting some dummy data:
<img width="506" alt="screenshot 2015-12-18 10 36 07" src="https://cloud.githubusercontent.com/assets/933586/11901144/f408b882-a577-11e5-87dc-d8dbe0fbf56f.png">
