### PR TITLE
Adds support for either blog or blogTag entries.

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -29,14 +29,14 @@ layout: bare
       {% endif %}
     {% endfor %}
   </p>
-  {% capture blog %}{{ project.blog }}{% endcapture %}
+  {% capture blog %}{{ project.blogTag | default: project.blog }}{% endcapture %}
   {% assign tags = blog | split: ',' %}
   {% if tags.size > 0 %}
     <p>
       <i class="fa fa-newspaper-o"></i>  /
       <span class="blog-tags" itemprop="keywords">
         {% for t in tags %}
-          <a href="https://18f.gsa.gov/tags/{{ t }}">News</a>
+          <a href="https://18f.gsa.gov/tags/{{ t | strip }}">News</a>
           /
         {% endfor %}
       </span>

--- a/index.html
+++ b/index.html
@@ -62,14 +62,14 @@ permalink: /
 
             <p><i class="fa fa-bar-chart"></i> / <a href="{{ site.baseurl }}/project/{{ project_name }}">Metrics</a> / </p>
 
-            {% capture blog %}{{ project.blog }}{% endcapture %}
+            {% capture blog %}{{ project.blogTag | default: project.blog }}{% endcapture %}
             {% assign tags = blog | split: ',' %}
             {% if tags.size > 0 %}
               <p>
                 <i class="fa fa-newspaper-o"></i> /
                 <span class="blog-tags" itemprop="keywords">
                   {% for t in tags %}
-                    <a href="https://18f.gsa.gov/tags/{{ t }}">News</a>
+                    <a href="https://18f.gsa.gov/tags/{{ t | strip }}">News</a>
                     /
                   {% endfor %}
                 </span>


### PR DESCRIPTION
Previously, about.yml used `blog` to define the blog tags to be called out for the individual project. The tag is in the process of being changed to `blogTag`. This commit will use either, but prefer `blogTag` if it is present.

Additionally, added a `strip` for the list of tags, because the common mistake of putting spaces between tags (i.e. `projectname, opendata, api` would yield incorrect urls for `opendata` (`https://18f.gsa.gov/tags/ opendata`) and `api`.

Resolves #310
