### PR TITLE
Live preview adjustments based on staging deployment

### DIFF
--- a/_includes/list-partners-preview.html
+++ b/_includes/list-partners-preview.html
@@ -1,4 +1,5 @@
-{% for agency in project.partners %}
-  <li>{{agency}}</li>
-{% endfor %}
+<li style="list-style-type: none;">Preview of the partner list is not yet available</li>
 
+<!-- {% for agency in project.partners %}
+  <li>{{agency}}</li>
+{% endfor %} -->

--- a/preview.html
+++ b/preview.html
@@ -1,7 +1,7 @@
 ---
 layout: project
 title: Live Preview
-permalink: /project/preview
+permalink: /project/preview/
 ---
 
 <script src="{{site.baseurl}}/assets/js/preview-bundle.js"></script>


### PR DESCRIPTION
Adds a trailing slash to preview permalink so that one does not need to include `.html` to access the page.

To close #315, this changes the partner list to inform the user that the live preview does not yet support partner lists.
