### PR TITLE
Updated go script to remove browserify from deploy cmd

### DIFF
--- a/go
+++ b/go
@@ -81,7 +81,6 @@ def deploy
   puts 'Pulling the latest changes...'
   exec_cmd('git pull')
   puts 'Building the site...'
-  exec_cmd('npm install && npm run browserify')
   exec_cmd('/opt/install/rbenv/shims/bundle exec jekyll b --trace')
   puts 'Site built successfully.'
   require 'time'


### PR DESCRIPTION
This _should_ at long last make a successful deployment on production. @DavidEBest @jeremiak @18F/dashboard 
