### PR TITLE
Use plugin to build javascript bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.pyc
 _data/projects.json
 node_modules/
+assets/js/preview-bundle.js

--- a/_plugins/build.rb
+++ b/_plugins/build.rb
@@ -1,0 +1,1 @@
+`npm install`

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "18f-dashboard",
   "repository": "git@github.com:18F/dashboard.git",
   "scripts": {
+    "install": "npm run browserify",
     "browserify": "browserify assets/js/preview.js -o assets/js/preview-bundle.js -t brfs",
     "watchify": "watchify assets/js/preview.js -o assets/js/preview-bundle.js -t brfs"
   },


### PR DESCRIPTION
Simple plugin to run `npm install` on Jekyll build. Also adds `npm install` script for `npm run browserify`. This should automatically generate the JS bundle on build in Federalist.
