### PR TITLE
Removes incorrect links and improves matching of existing partners.

### DIFF
--- a/_data/partners.yml
+++ b/_data/partners.yml
@@ -62,10 +62,18 @@ department-of-state:
   url: http://www.state.gov
   full_name: State Department
 department-of-health-and-human-services:
-  url: http://dhs.gov
+  url: http://www.hhs.gov/
   full_name: Department of Health and Human Services
   acronym: DHS
 department-of-justice:
   url: http://www.justice.gov/
   full_name: Justice Department
   acronym: DOJ
+small-business-administration:
+  url: https://www.sba.gov/
+  full_name: Small Business Administration
+  acronym: SBA
+department-of-labor:
+  url: https://www.dol.gov/
+  full_name: Department of Labor
+  acronym: DOL

--- a/_includes/list-partners.html
+++ b/_includes/list-partners.html
@@ -1,1 +1,17 @@
-{% for agency in project.partners %}{% capture agencyname %}{{ agency | slugify }}{% endcapture %}{% capture partnerurl %}{% for partner in site.data.partners %}{% if partner[0] == agencyname %}{{ partner[1].url }}{% else %} {% endif %}{% endfor %}{% endcapture %}{% if include.style == "list" %}{% unless partnerurl == " " %}<li><a href="{{ partnerurl }}">{{ agency }}</a></li>{% else %}<li>{{agency}}</li>{% endunless %}{% elsif include.style == "strong" %}{% unless partnerurl == " " %}<strong><a href="{{partnerurl}}">{{agency}}{% unless forloop.rindex == 1 %}, {% endunless%}</a></strong>{% else %}<strong>{{ agency }}</strong>{% endunless %}{% endif %}{% endfor %}
+{% for agency in project.partners %}
+  {% capture agencyname %}{{ agency | slugify }}{% endcapture %}
+  {% capture partnerurl %}{% for partner in site.data.partners %}{% if partner[0] == agencyname %}{{ partner[1].url }}{% else %}{% endif %}{% endfor %}{% endcapture %}
+  {% if include.style == "list" %}
+    {% unless partnerurl == empty %}
+      <li><a href="{{ partnerurl }}">{{ agency }}</a></li>
+    {% else %}
+      <li>{{agency}}</li>
+    {% endunless %}
+  {% elsif include.style == "strong" %}
+    {% unless partnerurl == empty %}
+      <strong><a href="{{partnerurl}}">{{agency}}</a>{% unless forloop.rindex == 1 %}, {% endunless%}</strong>
+    {% else %}
+      <strong>{{ agency }}{% unless forloop.rindex == 1 %}, {% endunless%}</strong>
+    {% endunless %}
+  {% endif %}
+{% endfor %}

--- a/_includes/list-partners.html
+++ b/_includes/list-partners.html
@@ -1,6 +1,6 @@
 {% for agency in project.partners %}
   {% capture agencyname %}{{ agency | slugify }}{% endcapture %}
-  {% capture partnerurl %}{% for partner in site.data.partners %}{% if partner[0] == agencyname %}{{ partner[1].url }}{% else %}{% endif %}{% endfor %}{% endcapture %}
+  {% capture partnerurl %}{% for partner in site.data.partners %}{% if partner[0] == agencyname or partner[1].full_name == agency %}{{ partner[1].url }}{% break %}{% else %}{% endif %}{% endfor %}{% endcapture %}
   {% if include.style == "list" %}
     {% unless partnerurl == empty %}
       <li><a href="{{ partnerurl }}">{{ agency }}</a></li>


### PR DESCRIPTION
- Removed dummy links
- Code now matches against both the 'slug name' and the full name.
- Added SBA, DOL to the partners list
- Corrected HHS (was pointing to DHS)
- Cleaned up the partner-list include a bit to improve legibility.

Fixes #333 
