### PR TITLE
Hiding the code line if no repos defined.

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,13 +53,14 @@ permalink: /
 
           <div>
             <p>{% if project.partners.size == 1 %}Partner: {%else%}Partners: {%endif%}{% if project.partners %}{% include list-partners.html style="strong" %}{% else %}Coming soon{% endif %}</p>
-            {% if project.github.first.name %}
-              {% assign repo_name = project.github.first.name %}
-            {% else %}
-              {% assign repo_name = project.github.first %}
+            {% if project.github %}
+              {% if project.github.first.name %}
+                {% assign repo_name = project.github.first.name %}
+              {% else %}
+                {% assign repo_name = project.github.first %}
+              {% endif %}
+              <p><i class="fa fa-github-alt"></i> / <a class="github-url" href="https://github.com/{{repo_name}}">Code</a> / </p>
             {% endif %}
-            <p><i class="fa fa-github-alt"></i> / <a class="github-url" href="https://github.com/{{repo_name}}">Code</a> / </p>
-
             <p><i class="fa fa-bar-chart"></i> / <a href="{{ site.baseurl }}/project/{{ project_name }}">Metrics</a> / </p>
 
             {% capture blog %}{{ project.blogTag | default: project.blog }}{% endcapture %}


### PR DESCRIPTION
Previously, the index page would include `code` links for all projects, even if they do not define a github repo. This adds a check for the value, and if absent, does not show the (bogus) info.

Fixes #331
