### PR TITLE
Correcting the way the tests used project_filter.yml

### DIFF
--- a/spec/homepage_spec.rb
+++ b/spec/homepage_spec.rb
@@ -1,4 +1,5 @@
-projects = YAML.load_file('_data/project_filter.yml')
+data = YAML.load_file('_data/project_filter.yml')
+projects = data['projects']
 RSpec.describe "the homepage", :type => :feature do
   it "loads with the expected number of projects listed" do
     visit 'http://127.0.0.1:4000/dashboard/'

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,4 +1,5 @@
-projects = YAML.load_file('_data/project_filter.yml')
+data = YAML.load_file('_data/project_filter.yml')
+projects = data['projects']
 RSpec.describe "project page", :type => :feature do
   projects.each_with_index do |project, index|
     it "#{project} should not have errors" do


### PR DESCRIPTION
The tests were failing because the format of the project_filter.yml file changed. This corrects them by having the tests read the project key of the filter file.
