### PR TITLE
Downcasing the project ids.

### DIFF
--- a/_plugins/dashboard.rb
+++ b/_plugins/dashboard.rb
@@ -129,7 +129,7 @@ module Dashboard
     def generate_project_pages(site)
       site.data['projects'].delete('all')
       site.data['projects'].each do |project_id, project|
-        ProjectPage.create site, project_id, project
+        ProjectPage.create site, project_id.downcase, project
       end
     end
   end

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@ permalink: /
               {% endif %}
               <p><i class="fa fa-github-alt"></i> / <a class="github-url" href="https://github.com/{{repo_name}}">Code</a> / </p>
             {% endif %}
-            <p><i class="fa fa-bar-chart"></i> / <a href="{{ site.baseurl }}/project/{{ project_name }}">Metrics</a> / </p>
+            <p><i class="fa fa-bar-chart"></i> / <a href="{{ site.baseurl }}/project/{{ project_name | slugify }}">Metrics</a> / </p>
 
             {% capture blog %}{{ project.blogTag | default: project.blog }}{% endcapture %}
             {% assign tags = blog | split: ',' %}


### PR DESCRIPTION
Capitalization of project names has been a problem. This remedies the issue by downcasing the project ids when the project is created.

@mtorres253, @gboone 

Fixes #334.
