### PR TITLE
Limit travis runs to deploying branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ before_install: npm install
 
 script: "./go ci_build"
 
+branches:
+  only:
+  - staging
+  - production
+
 git:
   submodules: false
 


### PR DESCRIPTION
This limits travis runs to only the `staging` and `production` branches
