### PR TITLE
Slugifying the project names on the stages page.

### DIFF
--- a/_includes/projectlist.html
+++ b/_includes/projectlist.html
@@ -3,7 +3,7 @@
   <ul>
   {% for project in site.data.projects %}
     {% if project[1]['stage'] == include.stage %}
-    <li><a href="{{site.baseurl}}/project/{{project[0]}}">{{ project[1]['full_name'] }}</a></li>
+    <li><a href="{{site.baseurl}}/project/{{project[0] | slugify}}">{{ project[1]['full_name'] }}</a></li>
     {% endif %}
   {% endfor %}
 </ul>


### PR DESCRIPTION
The stages page suffered from the capitalization issue that the index had in #342. This corrects it.
